### PR TITLE
Added support for extra_args during docker daemon start.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Tracks and builds [Docker](https://docker.io) images.
 
 * `email`: *Optional.* The email to use when authenticating.
 
+* `server_args`: *Optional.* Additional arguments to be passed during Docker daemon start.
+
 
 ## Behavior
 

--- a/assets/common.bash
+++ b/assets/common.bash
@@ -17,7 +17,7 @@ start_docker() {
   mkdir -p /var/lib/docker
   mount -t tmpfs -o size=10G none /var/lib/docker
 
-  docker -d >/dev/null 2>&1 &
+  docker $1 -d >/dev/null 2>&1 &
 
   sleep 1
 

--- a/assets/in
+++ b/assets/in
@@ -22,7 +22,9 @@ payload=$(mktemp /tmp/resource-in.XXXXXX)
 
 cat > $payload <&0
 
-start_docker
+extra_args=$(jq -r '.source.extra_args // ""' < $payload)
+
+start_docker "$extra_args"
 
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)

--- a/assets/in
+++ b/assets/in
@@ -22,9 +22,9 @@ payload=$(mktemp /tmp/resource-in.XXXXXX)
 
 cat > $payload <&0
 
-extra_args=$(jq -r '.source.extra_args // ""' < $payload)
+server_args=$(jq -r '.source.server_args // ""' < $payload)
 
-start_docker "$extra_args"
+start_docker "$server_args"
 
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -24,7 +24,9 @@ cat > $payload <&0
 
 cd $source
 
-start_docker
+extra_args=$(jq -r '.source.extra_args // ""' < $payload)
+
+start_docker "$extra_args"
 
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -24,9 +24,9 @@ cat > $payload <&0
 
 cd $source
 
-extra_args=$(jq -r '.source.extra_args // ""' < $payload)
+server_args=$(jq -r '.source.server_args // ""' < $payload)
 
-start_docker "$extra_args"
+start_docker "$server_args"
 
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)


### PR DESCRIPTION
This change, together with `FROM my-repository:5000/my-base-image` approach and
```
source:
  extra_args: --insecure-registry 192.168.59.103:5000
```
solves #4 issue.