### PR TITLE
Accept repositories from a private registries

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -25,6 +25,13 @@ if [ -z "$repository" ]; then
   exit 1
 fi
 
+if [[ "${repository}" =~ ^(.+)/(.+/.+)$ ]]; then
+  registry=${BASH_REMATCH[1]}
+  repository=${BASH_REMATCH[2]}
+else
+  registry=index.docker.io
+fi
+
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)
 
@@ -33,12 +40,12 @@ if [ -n "${username}" ] && [ -n "${password}" ]; then
 fi
 
 tags=$(mktemp /tmp/resource-in-tags.XXXXXX)
-curl ${curl_opts} "https://index.docker.io/v1/repositories/${repository}/tags" > $tags
+curl ${curl_opts} "https://${registry}/v1/repositories/${repository}/tags" > $tags
 
 shortened_image=$(jq -r "map(select(.name == $(echo $tag | jq -R .)))[].layer" < $tags)
 
 all_images=$(mktemp /tmp/resource-in-tags.XXXXXX)
-curl ${curl_opts} "https://index.docker.io/v1/repositories/${repository}/images" > $all_images
+curl ${curl_opts} "https://${registry}/v1/repositories/${repository}/images" > $all_images
 
 latest_image=$(jq -r "map(select(.id | startswith($(echo $shortened_image | jq -R .))))[0].id" < $all_images)
 


### PR DESCRIPTION
This will allow to specify repositories in private registries:

```
  - name: rabbit.docker
    type: docker-image
    source:
      repository: docker.mo.sap.corp/concourse/rabbit
```

If the registry host is omitted it will fallback to the default docker.io registy.