### PR TITLE
Support `docker import` for pushing exported rootfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ build.
 
 * `load_file`: *Optional.* A path to a file to `docker load` and then push.
 
+* `import_file`: *Optional.* A path to a file to `docker import` and then push.
+
 * `pull_repository`: *Optional.* A path to a repository to pull down, and
 then push to this resource.  
 

--- a/assets/out
+++ b/assets/out
@@ -68,6 +68,8 @@ load_file=$(jq -r '.params.load_file // ""' < $payload)
 load_repository=$(jq -r '.params.load_repository // ""' < $payload)
 load_tag=$(jq -r '.params.load_tag // "latest"' < $payload)
 
+import_file=$(jq -r '.params.import_file // ""' < $payload)
+
 pull_repository=$(jq -r '.params.pull_repository // ""' < $payload)
 pull_tag=$(jq -r '.params.pull_tag // "latest"' < $payload)
 
@@ -82,6 +84,8 @@ elif [ -n "$load" ]; then
 elif [ -n "$load_file" ]; then
   docker load -i $load_file
   docker tag "${load_repository}:${load_tag}" "${repository}:${tag_name}"
+elif [ -n "$import_file" ]; then
+  cat $import_file | docker import - "${repository}:${tag_name}"
 elif [ -n "$pull_repository" ]; then
   docker pull "${pull_repository}:${pull_tag}"
   docker tag "${pull_repository}:${pull_tag}" "${repository}:${tag_name}"


### PR DESCRIPTION
Buildpacks generates a rootfs.tar.gz for CF rootfses. We then need to push this tarball to Dockerhub.

The `docker load` command does not support loading tarballs that were exported via `docker export`. It only supports those saved via `docker save`. This PR adds support for importing tarballs generated by `docker export` to be pushed to Dockerhub.