### PR TITLE
Fix example config in README.md to include source repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ version is the image's ID.
 - name: machine-image
   type: docker-image
   source:
+    repository: concourse/some-image
     email: docker@example.com
     username: username
     password: password


### PR DESCRIPTION
This field was left out of the example, even though it is required.