### PR TITLE
use "tag_prefix" even if there is no "tag"

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -56,7 +56,11 @@ if [ -n "$tag_params" ]; then
   fi
   tag_name="${tag_prefix}$(cat $tag_params)"
 else
-  tag_name="$tag_source"
+  if [ -n "$tag_prefix"]; then
+    tag_name="$tag_prefix"
+  else
+    tag_name="$tag_source"
+  fi
 fi
 
 if [ -z "$repository" ]; then


### PR DESCRIPTION
(DO NOT MERGE, THIS IS UNTESTED, FOR DISCUSSION PURPOSES ONLY)

allow for the tag to be set from the pipeline itself (by using "tag-prefix"), rather than requiring a file. 

example:

```
- name: "publish "
  serial_groups: [pipeline-running]
  attempts: 3
  plan:
  - get: awesome-sources
    trigger: true
....
  - put: awesome-docker-image
    params:
       dockerfile:awesome-sources/Dockerfile
       build: awesome-sources
       tag_prefix: "BUILT_BUT_NOT_YET_TESTED"
```