### PR TITLE
Explicitly request v2 schema 2 manifests

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -44,11 +44,10 @@ func main() {
 	manifestURL, err := ub.BuildManifestURL(repo, tag)
 	fatalIf("failed to build manifest URL", err)
 
-        manifestRequest, err := http.NewRequest("GET", manifestURL, nil)
-        fatalIf("failed to build manifest request", err)
-        manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
- 
-        manifestResponse, err := client.Do(manifestRequest)
+	manifestRequest, err := http.NewRequest("GET", manifestURL, nil)
+	fatalIf("failed to build manifest request", err)
+	manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	manifestResponse, err := client.Do(manifestRequest)
 	fatalIf("failed to fetch manifest", err)
 
 	manifestResponse.Body.Close()

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -44,7 +44,11 @@ func main() {
 	manifestURL, err := ub.BuildManifestURL(repo, tag)
 	fatalIf("failed to build manifest URL", err)
 
-	manifestResponse, err := client.Get(manifestURL)
+        manifestRequest, err := http.NewRequest("GET", manifestURL, nil)
+        fatalIf("failed to build manifest request", err)
+        manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+ 
+        manifestResponse, err := client.Do(manifestRequest)
 	fatalIf("failed to fetch manifest", err)
 
 	manifestResponse.Body.Close()


### PR DESCRIPTION
This is a fix for #33
This fixes discovering digests on docker distribution >= 2.3.1 by explicitly requesting schema v2 manifests.
Before distribution 2.3.1 the v2 schema 1 manifests contained the schema 2 digest by accident which was fixed with this commit https://github.com/docker/distribution/commit/d7eb5d118a6a14a6f320062296b1808506c35241.
docker pull (at least on recent versions of docker) only works with v2 digest. So this only worked by accident until it was fixed.