### PR TITLE
Added application/json to manifestRequest Accept header

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -46,7 +46,8 @@ func main() {
 
 	manifestRequest, err := http.NewRequest("GET", manifestURL, nil)
 	fatalIf("failed to build manifest request", err)
-	manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json,application/json")
+	manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	manifestRequest.Header.Add("Accept", "application/json")
 	manifestResponse, err := client.Do(manifestRequest)
 	fatalIf("failed to fetch manifest", err)
 

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	manifestRequest, err := http.NewRequest("GET", manifestURL, nil)
 	fatalIf("failed to build manifest request", err)
-	manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json,application/json")
 	manifestResponse, err := client.Do(manifestRequest)
 	fatalIf("failed to fetch manifest", err)
 


### PR DESCRIPTION
As described in issue #40 a Docker registry in Artifactory 4.4.2 (and probably earlier) responds to the manifest request with content-type `application/json`, which results in a 406 return code. This change adds that content-type to the Accept header. Have tested against our Artifactory registry and also against the public Docker hub and both work.