### PR TITLE
Alternative ECR Support

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -82,6 +82,21 @@ stop_docker() {
   wait $pid
 }
 
+ecr_registry() {
+    local repository="${1}"
+
+    if echo "${repository}" | grep -q -e '\.ecr\.[^\.]*\.amazonaws\.com' ; then
+        return 0
+    fi
+
+    return 1
+}
+
+ecr_registry_region() {
+    local registry="${1}"
+    echo "${registry}" | cut -d. -f4
+}
+
 private_registry() {
   local repository="${1}"
 

--- a/assets/in
+++ b/assets/in
@@ -32,7 +32,7 @@ repository="$(jq -r '.source.repository // ""' < $payload)"
 tag="$(jq -r '.source.tag // "latest"' < $payload)"
 ca_certs=$(jq -r '.source.ca_certs // []' < $payload)
 
-if private_registry "${repository}" ; then
+if private_registry "${repository}" || ecr_registry "${repository}" ; then
   registry="$(extract_registry "${repository}")"
 else
   registry=
@@ -54,6 +54,9 @@ image_name="${repository}@${digest}"
 if [ "$skip_download" = "false" ]; then
   if [ -n "${username}" ] && [ -n "${password}" ]; then
     docker login -u "${username}" -p "${password}" ${registry}
+  elif ecr_registry "${repository}"; then
+    aws_region="$(ecr_registry_region "${repository}")"
+    eval $(aws --region="${aws_region}" ecr get-login)
   fi
 
   docker_pull "$image_name"

--- a/assets/out
+++ b/assets/out
@@ -33,7 +33,7 @@ password=$(jq -r '.source.password // ""' < $payload)
 repository=$(jq -r '.source.repository // ""' < $payload)
 ca_certs=$(jq -r '.source.ca_certs // []' < $payload)
 
-if private_registry "${repository}" ; then
+if private_registry "${repository}" || ecr_registry "${repositor}" ; then
   registry="$(extract_registry "${repository}")"
 else
   registry=
@@ -44,6 +44,9 @@ start_docker "$insecure_registries" "$registry_mirror"
 
 if [ -n "${username}" ] && [ -n "${password}" ]; then
   docker login -u "${username}" -p "${password}" ${registry}
+elif ecr_registry "${repository}"; then
+  aws_region="$(ecr_registry_region "${repository}")"
+  eval $(aws --region="${aws_region}" ecr get-login)
 fi
 
 tag_source=$(jq -r '.source.tag // "latest"' < $payload)


### PR DESCRIPTION
In light of the concern from @vito on #37, specifically in terms of getting credentials from multiple sources, I reworked it slightly to support a scenario where the instance has an IAM profile and thus the user will not be providing any credentials at all.

This will require vendoring the awscli, but I profess to not understanding the innards of Concourse quite well enough to see how that would be done.

In all other circumstances where a user would be providing credentials, I'd defer to concourse/concourse#291