### PR TITLE
Use a local "registry" variable in start_docker

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -50,6 +50,7 @@ start_docker() {
   fi
 
   local server_args=""
+  local registry=""
 
   for registry in $1; do
     server_args="${server_args} --insecure-registry ${registry}"


### PR DESCRIPTION
The `registry` variable used in the loop in `common.sh/start_docker` will override the one in the outer scope (e.g. in [`out`](https://github.com/concourse/docker-image-resource/blob/master/assets/in#L56))
Most of the time this doesn't matter as they are the same.  However it is possible, as in my case, that the `insecure_registries` lists a private registry containing the base image which differs from the registry being published too, so the values will be different.