### PR TITLE
Cache tag parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ version is the image's digest.
   intermediate images when building). This will cause the resource to fail
   if it is set to `true` and the image does not exist yet.
 
+* `cache_tag`: *Optional.* Default `tag`. The specific tag to pull before
+  building when `cache` parameter is set. Instead of pulling the same tag
+  that's going to be built, this allows picking a different tag like
+  `latest` or the previous version. This will cause the resource to fail
+  if it is set to a tag that does not exist yet.
+
 * `load_base`: *Optional.* A path to a directory containing an image to `docker
   load` before running `docker build`. The directory must have `image`,
   `image-id`, `repository`, and `tag` present, i.e. the tree produced by `/in`.

--- a/assets/out
+++ b/assets/out
@@ -73,6 +73,7 @@ load=$(jq -r '.params.load // ""' < $payload)
 load_base=$(jq -r '.params.load_base // ""' < $payload)
 build=$(jq -r '.params.build // ""' < $payload)
 cache=$(jq -r '.params.cache' < $payload)
+cache_tag=$(jq -r '.params.cache_tag // "${tag_name}"' < $payload)
 dockerfile=$(jq -r '.params.dockerfile // ""' < $payload)
 
 load_file=$(jq -r '.params.load_file // ""' < $payload)
@@ -96,7 +97,7 @@ elif [ -n "$build" ]; then
   fi
 
   if [ "$cache" = "true" ]; then
-    docker_pull "${repository}:${tag_name}"
+    docker_pull "${repository}:${cache_tag}"
   fi
 
   if [ -n "$dockerfile" ]; then


### PR DESCRIPTION
This pull request allows specifying a different tag to pull for caching. This way caching can be used even when a new tag is built. For our case we use a new image tag for each git commit. As it is right now, we can't use `cache` in this case. With this pull request we'd be able to use `tag_as_latest: True` and `cache_tag: latest` to enable caching and cut down build times.