### PR TITLE
Request: Output the docker inspect information from the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The following files will be placed in the destination:
 * `/digest`: The fetched image digest.
 * `/rootfs.tar`: If `rootfs` is `true`, the contents of the image will be
   provided here.
+* `/metadata.json`: Collects custom metadata. Contains the container  `env` variables and running `user`.
+* `/docker_inspect.json`: Output of the `docker inspect` on `image_id`. Useful if collecting `LABEL` [metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/) from your image.
 
 #### Parameters
 

--- a/assets/in
+++ b/assets/in
@@ -79,6 +79,9 @@ fi
 
 image_id="$(image_from_digest "$repository" "$digest")"
 
+# Let's collect the metadata on the image from docker inspect
+docker inspect $image_id > ${destination}/docker_inspect.json
+
 echo "$repository" > ${destination}/repository
 echo "$tag" > ${destination}/tag
 echo "$image_id" > ${destination}/image-id


### PR DESCRIPTION
This can help us pass context via "LABEL" and other image information natively supported by the docker image.