### PR TITLE
Changes skip_download functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ The following files will be placed in the destination:
 
 #### Parameters
 
-* `save`: *Optional.* Place a `docker save`d image in the destination.
 * `rootfs`: *Optional.* Place a `.tar` file of the image in the destination.
-* `skip_download`: *Optional.* Skip `docker pull` of image. Only `/image-id`,
+* `download`: *Optional.* Default `false`. Performs `docker pull` of image. If not set to true, Only `/image-id`,
   `/repository`, and `/tag` will be populated. `/image` and `/rootfs.tar` will
   not be present.
+* `save`: *Optional.* Place a `docker save`d image in the destination.
 
 
 ### `out`: Push an image, or build and push a `Dockerfile`.
@@ -112,11 +112,11 @@ version is the image's digest.
   if it is set to `true` and the image does not exist yet.
   Note: Since docker 1.10 docker images [do not contain all necessary metadata to
   restore the build cache](https://github.com/docker/docker/issues/20316).
-  Additional metadata needs to be saved and re-applied after a docker pull to have 
+  Additional metadata needs to be saved and re-applied after a docker pull to have
   subsequent builds skip identical intermediate layers. This additional
   metadata is stored as a very small separate image (`image:${cache_tag}-buildcache`)
   in the repository of this resource.
-  
+
 * `cache_tag`: *Optional.* Default `tag`. The specific tag to pull before
   building when `cache` parameter is set. Instead of pulling the same tag
   that's going to be built, this allows picking a different tag like
@@ -153,7 +153,7 @@ version is the image's digest.
   be tagged as `latest` in addition to whatever other tag was specified.
 
 * `build_args`: *Optional.*  A map of Docker build arguments.
-  
+
   Example:
 
   ```yaml
@@ -162,7 +162,7 @@ version is the image's digest.
     how_many_things: 2
     email: me@yopmail.com
   ```
-    
+
 * `build_args_file`: *Optional.* Path to a JSON file containing Docker build
   arguments.
 

--- a/assets/in
+++ b/assets/in
@@ -44,7 +44,7 @@ fi
 digest="$(jq -r '.version.digest' < $payload)"
 
 rootfs="$(jq -r '.params.rootfs // false' < $payload)"
-skip_download="$(jq -r '.params.skip_download // false' < $payload)"
+download="$(jq -r '.params.download // false' < $payload)"
 save="$(jq -r '.params.save // false' < $payload)"
 
 certs_to_file "$ca_certs"
@@ -54,7 +54,7 @@ mkdir -p $destination
 
 image_name="${repository}@${digest}"
 
-if [ "$skip_download" = "false" ]; then
+if [ "$download" = "true" ] || [ "$save" = "true" ]; then
   log_in "$username" "$password" "$registry"
 
   docker_pull "$image_name"
@@ -62,7 +62,7 @@ if [ "$skip_download" = "false" ]; then
   if [ "$save" = "true" ]; then
     docker save -o ${destination}/image "$image_name"
   fi
-  
+
   image_id="$(image_from_digest "$repository" "$digest")"
 
   echo "$image_id" > ${destination}/image-id


### PR DESCRIPTION
## Problem

Concourse automatically implements a `get` task after a `push` task to get updated version information.  Generally this is not an issue, but with Docker builds this results in a `docker pull` being performed.  In many cases this can lead to significant time and bandwidth consumption on builds.  The docker-image resource implements a `skip_download` parameter, but this only applies to manually created `get` tasks and there is no way to apply a `skip_download: true` to the `get` action that is automatically performed.

## Solution

My proposed solution is to change the `skip_download` parameter to `download` and set the default action to false.  This will cause the automatic `get` action to skip the download and only get the necessary version data.  I have also added a conditional to perform the download action if the `save` parameter is set to true, as a download will be required in order to perform the save.

## Causes for Concern

The only real downside of this change is that resources that currently implement a `get` action will now have to have a `download: true` added to their parameters.  However, I would argue that the added benefits (namely potentially saving a TON of time and bandwidth for everyone) outweigh the cons of having to add this parameter.

Another concern is how it will affect tasks via the docker-image resource.  However, provided the task resource sets`save: true` it should still work as intended.