### PR TITLE
Added timeout to pingClient.

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -182,8 +182,11 @@ func makeTransport(logger lager.Logger, request CheckRequest, registryHost strin
 
 	authTransport := transport.NewTransport(baseTransport)
 
+	timeout := time.Duration(10 * time.Second)
+
 	pingClient := &http.Client{
 		Transport: retryRoundTripper(logger, authTransport),
+		Timeout: timeout,
 	}
 
 	challengeManager := auth.NewSimpleChallengeManager()

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -182,11 +182,9 @@ func makeTransport(logger lager.Logger, request CheckRequest, registryHost strin
 
 	authTransport := transport.NewTransport(baseTransport)
 
-	timeout := time.Duration(10 * time.Second)
-
 	pingClient := &http.Client{
 		Transport: retryRoundTripper(logger, authTransport),
-		Timeout: timeout,
+		Timeout: 1 * time.Minute,
 	}
 
 	challengeManager := auth.NewSimpleChallengeManager()


### PR DESCRIPTION
We should add a timeout in case pingClient fails, otherwise check will just hang and we will never see the error that caused pingClient to fail. 