### PR TITLE
Support for pulling a digest in the out of the resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ version is the image's digest.
 * `pull_tag`: *Optional.*  Default `latest`. The tag of the repository to pull
   down via `pull_repository`.
 
+* `pull_digest`: *Optional.* The digest of image to pull down via `pull_repository`. If both `pull_tag` and `pull_digest` are set, `pull_tag` will be ignored.
+
 * `tag`: *Optional.* The value should be a path to a file containing the name
   of the tag.
 

--- a/assets/out
+++ b/assets/out
@@ -86,6 +86,7 @@ import_file=$(jq -r '.params.import_file // ""' < $payload)
 
 pull_repository=$(jq -r '.params.pull_repository // ""' < $payload)
 pull_tag=$(jq -r '.params.pull_tag // "latest"' < $payload)
+pull_digest=$(jq -r '.params.pull_digest // ""' < $payload)
 
 if [ -n "$load" ]; then
   docker load -i "${load}/image"
@@ -132,8 +133,13 @@ elif [ -n "$load_file" ]; then
 elif [ -n "$import_file" ]; then
   cat "$import_file" | docker import - "${repository}:${tag_name}"
 elif [ -n "$pull_repository" ]; then
-  docker pull "${pull_repository}:${pull_tag}"
-  docker tag "${pull_repository}:${pull_tag}" "${repository}:${tag_name}"
+  if [ -n "$pull_digest" ]; then
+    docker pull "${pull_repository}@${pull_digest}"
+    docker tag "${pull_repository}@${pull_digest}" "${repository}:${tag_name}"
+  else
+    docker pull "${pull_repository}:${pull_tag}"
+    docker tag "${pull_repository}:${pull_tag}" "${repository}:${tag_name}"
+  fi
 else
   echo "must specify build, load, load_file, import_file, or pull_repository params"
   exit 1


### PR DESCRIPTION
This patch adds support for setting `$pull_digest` instead of `$pull_tag` when using `$pull_repository`