### PR TITLE
Treat Source.Tag as a json.Number

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -60,7 +60,7 @@ func main() {
 		registryHost = registryMirrorUrl.Host
 	}
 
-	tag := request.Source.Tag
+	tag := request.Source.Tag.String()
 	if tag == "" {
 		tag = "latest"
 	}

--- a/cmd/check/models.go
+++ b/cmd/check/models.go
@@ -1,8 +1,10 @@
 package main
 
+import "encoding/json"
+
 type Source struct {
 	Repository         string          `json:"repository"`
-	Tag                string          `json:"tag"`
+	Tag                json.Number     `json:"tag"`
 	Username           string          `json:"username"`
 	Password           string          `json:"password"`
 	InsecureRegistries []string        `json:"insecure_registries"`


### PR DESCRIPTION
If a tag is specified in yaml like:

```
tag: 2
```

It will get turned into json as `{"tag": 2}`. We could try to fix this at the Go yaml->json level, but I think it's harder than just handling either here. json.Number can handle a thing that is totally a string (`{"tag": "foo"}`), or just sorta a string (`{"tag": 2.5}`).

I encountered this when trying to use the Ruby 2.1 docker image. I had to add quotes around the tag in my pipeline. I got this very confusing error in my task that was using that docker image:

```
resource script '/opt/resource/check []' failed: exit status 1

stderr:
failed to read request: json: cannot unmarshal number into Go value of type string
```