### PR TITLE
Support for pushing multiple tags

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -51,6 +51,7 @@ log_in "$username" "$password" "$registry"
 tag_source=$(jq -r '.source.tag // "latest"' < $payload)
 tag_params=$(jq -r '.params.tag // ""' < $payload)
 tag_prefix=$(jq -r '.params.tag_prefix // ""' < $payload)
+additional_tags=$(jq -r '.params.additional_tags // ""' < $payload)
 need_tag_as_latest=$(jq -r '.params.tag_as_latest // "false"' < $payload)
 build_args=$(jq -r '.params.build_args // []' < $payload)
 build_args_file=$(jq -r '.params.build_args_file // ""' < $payload)
@@ -65,6 +66,15 @@ if [ -n "$tag_params" ]; then
   tag_name="${tag_prefix}$(cat $tag_params)"
 else
   tag_name="$tag_source"
+fi
+
+additional_tag_names=""
+if [ -n "$additional_tags" ]; then
+  if [ ! -f "$additional_tags" ]; then
+    echo "additional tags file '$additional_tags' does not exist"
+    exit 1
+  fi
+  additional_tag_names="$(cat $additional_tags)"
 fi
 
 if [ -z "$repository" ]; then
@@ -178,6 +188,14 @@ if [ "$need_tag_as_latest" = "true" ] && [ "${tag_name}" != "latest"  ]    ; the
   docker tag "${repository}:${tag_name}" "${repository}:latest"
   docker push "${repository}:latest"
   echo "${repository}:${tag_name} tagged as latest"
+fi
+
+if [ -n "$additional_tag_names" ]    ; then
+  for additional_tag in $additional_tag_names; do
+    docker tag "${repository}:${tag_name}" "${repository}:${additional_tag}"
+    docker push "${repository}:${additional_tag}"
+    echo "${repository}:${tag_name} tagged as ${additional_tag}"
+  done
 fi
 
 jq -n "{


### PR DESCRIPTION
Fixes #98.

This is a very quick implementation that adds a new `additional_tags` parameter. `additional_tags` should reference a file that contains a whitespace-separated list of tags.

I've done minimal testing so far, except to confirm that it does indeed push the image with each of the additional tags and that it doesn't break if `additional_tags` isn't provided.