### PR TITLE
Propagate worker proxy settings when building docker images

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -113,6 +113,14 @@ elif [ -n "$build" ]; then
 
   expanded_build_args=()
 
+  # propagate proxy settings to image builder
+  for proxy_var in http_proxy https_proxy no_proxy ; do
+    if [ -n "${!proxy_var:-}" ]; then
+      expanded_build_args+=("--build-arg")
+      expanded_build_args+=("${proxy_var}=${!proxy_var}")
+    fi
+  done
+
   build_arg_keys=($(echo "$build_args" | jq -r 'keys | join(" ")'))
   if [ "${#build_arg_keys[@]}" -gt 0 ]; then
     for key in "${build_arg_keys[@]}"; do


### PR DESCRIPTION
Solves issue #131

Concourse supports passing the http_proxy family of environment variables from the workers to the containers running on them: concourse/concourse#319

These environment variables do not propagate, however, when building a docker image with docker-image-resource which leaves a pretty large blind spot. This PR fixes that by adding all present proxy setting environment variables as build arguments.

You may see this warning during docker image build if you have proxy environment variable enabled:
`[Warning] One or more build-args [http_proxy https_proxy] were not consumed`

This is because Docker fails to detect that these arguments are being used (even when they're used). It's thankfully harmless.