### PR TITLE
Add default to SKIP_PRIVILEGED

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,28 @@ environment is consistent across any `docker` enabled platform. When the docker
 image builds, the test are run inside the docker container, on failure they
 will stop the build.
 
-Run the tests with the following command:
+Build the image and run the tests with the following command:
 
 ```sh
 docker build -t docker-image-resource .
+```
+
+To use the newly built image, push it to a docker registry that's accessible to
+Concourse and configure your pipeline to use it:
+
+```yaml
+resource_types:
+- name: docker-image-resource
+  type: docker-image
+  privileged: true
+  source:
+    repository: example.com:5000/docker-image-resource
+    tag: latest
+
+resources:
+- name: some-image
+  type: docker-image-resource
+  ...
 ```
 
 ### Contributing

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -44,7 +44,7 @@ start_docker() {
   mkdir -p /var/log
   mkdir -p /var/run
 
-  if [ -z "$SKIP_PRIVILEGED" ]; then
+  if [ -z "${SKIP_PRIVILEGED-""}" ]; then
     sanitize_cgroups
 
     # check for /proc/sys being mounted readonly, as systemd does


### PR DESCRIPTION
In the event that SKIP_PRIVILEGED is not set and common.sh is sourced
into a file that has `set -u`, it will error:

```
/opt/resource/common.sh: line 47: SKIP_PRIVILEGED: unbound variable
```

I discovered this while trying to build HEAD of docker-image-resource to
be used as a resource_type. The image built but put was failing with the
above error.

The test used will substitute parameter if it is set and not null,
otherwise set null if the parameter is null, otherwise use "" (null) if
it is unset. See http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02 for a table explaining each.