### PR TITLE
Allow multiple ECR images in dockerfile

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -148,15 +148,18 @@ elif [ -n "$build" ]; then
   fi
 
   ECR_REGISTRY_PATTERN='/[a-zA-Z0-9][a-zA-Z0-9_-]*\.dkr\.ecr\.[a-zA-Z0-9][a-zA-Z0-9_-]*\.amazonaws\.com(\.cn)?[^ ]*/'
-  ecr_image=$(grep '^\s*FROM' ${dockerfile} | \
+  ecr_images=$(grep '^\s*FROM' ${dockerfile} | \
              awk "match(\$0,${ECR_REGISTRY_PATTERN}){print substr(\$0, RSTART, RLENGTH)}" )
-  if [ -n "$ecr_image" ]; then
-    # pull will perform an authentication process needed for ECR
-    # there is an experimental endpoint to support long running sessions
-    # docker cli does not support it yet though
-    # see https://github.com/moby/moby/pull/32677
-    # and https://github.com/awslabs/amazon-ecr-credential-helper/issues/9
-    docker pull "${ecr_image}"
+  if [ -n "$ecr_images" ]; then
+    for ecr_image in $ecr_images
+    do
+      # pull will perform an authentication process needed for ECR
+      # there is an experimental endpoint to support long running sessions
+      # docker cli does not support it yet though
+      # see https://github.com/moby/moby/pull/32677
+      # and https://github.com/awslabs/amazon-ecr-credential-helper/issues/9
+      docker pull "${ecr_image}"
+    done    
   fi
 
   docker build -t "${repository}:${tag_name}" "${expanded_build_args[@]}" -f "$dockerfile" $cache_from "$build"

--- a/tests/fixtures/ecr/Dockerfile.multi-ecr
+++ b/tests/fixtures/ecr/Dockerfile.multi-ecr
@@ -1,0 +1,6 @@
+FROM ubuntu as u
+
+FROM 123123.dkr.ecr.us-west-2.amazonaws.com:443/testing as test
+
+FROM 123123.dkr.ecr.us-west-2.amazonaws.com:443/testing2 as test
+

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Out", func() {
 			Expect(session.Err).To(gbytes.Say(docker("pull 123123.dkr.ecr.us-west-2.amazonaws.com:443/testing")))
 		})
 
-		It("calls docker pull for an ECR images in a multi build docker file", func() {
+		It("calls docker pull for an ECR image in a multi build docker file", func() {
 			session := put(map[string]interface{}{
 				"source": map[string]interface{}{
 					"repository": "test",
@@ -177,6 +177,21 @@ var _ = Describe("Out", func() {
 			})
 
 			Expect(session.Err).To(gbytes.Say(docker("pull 123123.dkr.ecr.us-west-2.amazonaws.com:443/testing")))
+		})
+
+		It("calls docker pull for all ECR images in a multi build docker file", func() {
+			session := put(map[string]interface{}{
+				"source": map[string]interface{}{
+					"repository": "test",
+				},
+				"params": map[string]interface{}{
+					"build":      "/docker-image-resource/tests/fixtures/ecr",
+					"dockerfile": "/docker-image-resource/tests/fixtures/ecr/Dockerfile.multi-ecr",
+				},
+			})
+
+			Expect(session.Err).To(gbytes.Say(docker("pull 123123.dkr.ecr.us-west-2.amazonaws.com:443/testing")))
+			Expect(session.Err).To(gbytes.Say(docker("pull 123123.dkr.ecr.us-west-2.amazonaws.com:443/testing2")))
 		})
 	})
 


### PR DESCRIPTION
If a multi-part build contains more than one ECR base image then the build fails with an `invalid reference format` error. This is due to the docker pull for ECR trying to fetch both images in one command `docker pull <image1> <image2>`.

This PR performs a `docker pull` for each ECR image found in the Dockerfile.