### PR TITLE
Add support for multiple load bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ version is the image's digest.
   load` before running `docker build`. The directory must have `image`,
   `image-id`, `repository`, and `tag` present, i.e. the tree produced by `/in`.
 
+* `load_bases`: *Optional.* Same as `load_base`, but takes an array to load
+  multiple images.
+
 * `load_file`: *Optional.* A path to a file to `docker load` and then push.
   Requires `load_repository`.
 

--- a/assets/out
+++ b/assets/out
@@ -81,6 +81,7 @@ fi
 load=$(jq -r '.params.load // ""' < $payload)
 
 load_base=$(jq -r '.params.load_base // ""' < $payload)
+load_bases=$(jq -r '.params.load_bases // empty' < $payload)
 build=$(jq -r '.params.build // ""' < $payload)
 cache=$(jq -r '.params.cache' < $payload)
 cache_tag=$(jq -r ".params.cache_tag // \"${tag_name}\"" < $payload)
@@ -109,6 +110,15 @@ elif [ -n "$build" ]; then
     docker tag \
       "$(cat "${load_base}/image-id")" \
       "$(cat "${load_base}/repository"):$(cat "${load_base}/tag")"
+  fi
+
+  if [ -n "$load_bases" ]; then
+    for load_base in $(echo $load_bases | jq -r '.[]'); do
+      docker load -i "${load_base}/image"
+      docker tag \
+        "$(cat "${load_base}/image-id")" \
+        "$(cat "${load_base}/repository"):$(cat "${load_base}/tag")"
+    done
   fi
 
   cache_from=""


### PR DESCRIPTION
Docker supports [multi-stage builds](https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds), which allows for creating smaller resulting Docker images by throwing away intermediate containers.

Using multi-stage builds typically results in two or more `FROM` statements in the `Dockerfile`, so it makes sense to want to load multiple images to speed up building images.

I've added this as `load_bases` for simplicity, but I realize there's history with `load` and `load_base` as evidenced by `assets/out`.

I'm all for using a different key; when one is settled on I'll update the README as well.

Sample configuration:

```
  - put: deploy-image
    params:
      build: workspace
      dockerfile: workspace/Dockerfile
      load_bases:
      - golang
      - debian
```
  