### PR TITLE
docker: force create systemd cgroup

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -39,6 +39,11 @@ sanitize_cgroups() {
       ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
     fi
   done
+
+  if ! test -e /sys/fs/cgroup/systemd ; then
+    mkdir /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
+  fi
 }
 
 start_docker() {


### PR DESCRIPTION
This appears to now be necessary to start docker; otherwise we get a confusing `cgroups: cannot found cgroup mount destination: unknown` error the first time a docker step involves running executables.

Fixes #174