### PR TITLE
Add support for using zfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,15 @@ RUN set -e; for pkg in $(go list ./...); do \
 	done
 
 FROM alpine:edge AS resource
-RUN apk --no-cache add bash docker jq ca-certificates
+RUN apk --no-cache add bash docker jq ca-certificates \
+    btrfs-progs \
+		e2fsprogs \
+		e2fsprogs-extra \
+		iptables \
+		xfsprogs \
+		xz \
+    zfs
+
 COPY --from=builder /assets /opt/resource
 RUN mv /opt/resource/ecr-login /usr/local/bin/docker-credential-ecr-login
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -87,6 +87,9 @@ stop_docker() {
     return 0
   fi
 
+  echo "purge docker to avoid host resource leaks"
+  docker system prune -a -f
+
   kill -TERM $pid
 }
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -87,8 +87,8 @@ stop_docker() {
     return 0
   fi
 
-  echo "purge docker to avoid host resource leaks"
-  docker system prune -a -f
+  echo "purging docker to avoid host resource leaks"
+  docker system prune -a -f > /dev/null
 
   kill -TERM $pid
 }


### PR DESCRIPTION
This adds the alpine zfs package so that docker can use the zfs storage backend if it's available.

Additionally, this purges docker entirely before exitting to prevent any resource leakage (something that, no surprise, happens when you use the zfs storage backend nested. The zfs filesystems that the inner docker creates are left as zombies on the host system)