### PR TITLE
create_ecr_repo: If the repository is an ECR repo check if it exists and create if it doesn't

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN set -e; for pkg in $(go list ./...); do \
 	done
 
 FROM alpine:edge AS resource
-RUN apk --no-cache add bash docker jq ca-certificates
+RUN apk --no-cache add bash docker jq ca-certificates python py-pip
+RUN pip install --upgrade awscli
 COPY --from=builder /assets /opt/resource
 RUN mv /opt/resource/ecr-login /usr/local/bin/docker-credential-ecr-login
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
 * `aws_session_token`: *Optional.* AWS session token (assumed role) to use for acquiring ECR
   credentials.
 
+* `aws_default_region`: *Optional.* AWS region required when using aws cli for ECR.
+
 * `insecure_registries`: *Optional.* An array of CIDRs or `host:port` addresses
   to whitelist for insecure access (either `http` or unverified `https`).
   This option overrides any entries in `ca_certs` with the same address.

--- a/assets/out
+++ b/assets/out
@@ -39,6 +39,7 @@ max_concurrent_uploads=$(jq -r '.source.max_concurrent_uploads // 3' < $payload)
 export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // ""' < $payload)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // ""' < $payload)
 export AWS_SESSION_TOKEN=$(jq -r '.source.aws_session_token // ""' < $payload)
+export AWS_DEFAULT_REGION=$(jq -r '.source.aws_default_region // ""' < $payload)
 
 if private_registry "${repository}" ; then
   registry="$(extract_registry "${repository}")"
@@ -227,6 +228,21 @@ else
 fi
 
 image_id="$(image_from_tag "$repository" "$tag_name")"
+
+# Ensure repository is created if repository is an ECR repo
+ecr_image=$(echo $repository | \
+           awk "match(\$0,${ECR_REGISTRY_PATTERN}){print substr(\$0, RSTART, RLENGTH)}" )
+
+if [ -n "$ecr_image" ]; then
+  repository_name=$(echo $repository | awk -F/ '{print substr($0, index($0, $2))}')
+  repo_exists=$(aws ecr describe-repositories --repository-names $repository_name 2>/dev/null | jq '.|length')
+  if [ ! -n "$repo_exists" ]; then
+    aws ecr create-repository --repository-name ${repository_name}
+    echo "${repository_name} created in ECR"
+  else
+    echo "${repository_name} already exists in ECR"
+  fi
+fi
 
 # afaict there's no clean way to get the digest after a push. docker prints
 # this line at the end at least:

--- a/assets/out
+++ b/assets/out
@@ -227,8 +227,6 @@ else
   exit 1
 fi
 
-image_id="$(image_from_tag "$repository" "$tag_name")"
-
 # Ensure repository is created if repository is an ECR repo
 ecr_image=$(echo $repository | \
            awk "match(\$0,${ECR_REGISTRY_PATTERN}){print substr(\$0, RSTART, RLENGTH)}" )
@@ -243,6 +241,8 @@ if [ -n "$ecr_image" ]; then
     echo "${repository_name} already exists in ECR"
   fi
 fi
+
+image_id="$(image_from_tag "$repository" "$tag_name")"
 
 # afaict there's no clean way to get the digest after a push. docker prints
 # this line at the end at least:


### PR DESCRIPTION
This PR will do the following:-

* Check if the repository being built is an ECR repo
* If it is get the repository name without the ecr url
* Check if the repository exists in ECR
* If it doesn't create the repository

To do this I've also added the following dependencies:-

* awscli, installed via pip, so python and py-pip also installed
* aws_default_region for the source configuration to set the default region which is required when using the aws cli with ECR