### PR TITLE
Avoid indefinitely echoing while waiting for docker

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -80,11 +80,12 @@ start_docker() {
 
   sleep 1
 
-  echo waiting for docker to come up...
-
-  until docker info >/dev/null 2>&1; do
-    sleep 1
-  done
+  if ! docker info >/dev/null 2>&1; then
+    echo waiting for docker to come up...
+    until docker info >/dev/null 2>&1; do
+      sleep 1
+    done
+  fi
 }
 
 stop_docker() {

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -80,8 +80,9 @@ start_docker() {
 
   sleep 1
 
+  echo waiting for docker to come up...
+
   until docker info >/dev/null 2>&1; do
-    echo waiting for docker to come up...
     sleep 1
   done
 }


### PR DESCRIPTION
While waiting for docker to come up, sometimes this can take awhile,
especially when docker will never come up and something else will
timeout. Having the echo within the loop can leave you with many, many
lines of repeated stdout. This is unecessary output that provides no
value and can cause issues when builds fail with many 10s of thousands of
outputted lines and the browser attempts to load the build output.