### PR TITLE
Installs the xz library into the resource image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN set -e; for pkg in $(go list ./...); do \
 	done
 
 FROM alpine:edge AS resource
-RUN apk --no-cache add bash docker jq ca-certificates
+RUN apk --no-cache add bash docker jq ca-certificates xz
 COPY --from=builder /assets /opt/resource
 RUN mv /opt/resource/ecr-login /usr/local/bin/docker-credential-ecr-login
 


### PR DESCRIPTION
The ADD command in the Dockerfile extracts a local tar archive
if its recognized as a gzip, bzip2 or xz.
But in this case the xz library is missing form the standard alpine:edge image.