### PR TITLE
Add support for image digest and spare roundtrip to ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
 
 * `tag`: *Optional.* The tag to track. Defaults to `latest`.
 
+* `Digest`: *Optional.* The image digest. If set `tag` will be ignored.
+
 * `username`: *Optional.* The username to authenticate with when pushing.
 
 * `password`: *Optional.* The password to use when authenticating.

--- a/cmd/check/models.go
+++ b/cmd/check/models.go
@@ -5,6 +5,7 @@ import "encoding/json"
 type Source struct {
 	Repository         string          `json:"repository"`
 	Tag                json.Number     `json:"tag"`
+	Digest             string          `json:"digest"`
 	Username           string          `json:"username"`
 	Password           string          `json:"password"`
 	InsecureRegistries []string        `json:"insecure_registries"`


### PR DESCRIPTION
... registry if digest is set
- image digests are immutable, no need to explicitly check it or for new versions
- in case of docker registry downtime, job would be still able to be scheduled in case digest is set