### PR TITLE
do not start dockerd in 'in' script if skip_download is set to true

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -51,19 +51,19 @@ rootfs="$(jq -r '.params.rootfs // false' < $payload)"
 skip_download="$(jq -r '.params.skip_download // false' < $payload)"
 save="$(jq -r '.params.save // false' < $payload)"
 
-certs_to_file "$ca_certs"
-set_client_certs "$client_certs"
-start_docker \
-	"${max_concurrent_downloads}" \
-	"${max_concurrent_uploads}" \
-	"$insecure_registries" \
-	"$registry_mirror"
-
 mkdir -p $destination
 
 image_name="${repository}@${digest}"
 
 if [ "$skip_download" = "false" ]; then
+  certs_to_file "$ca_certs"
+  set_client_certs "$client_certs"
+  start_docker \
+    "${max_concurrent_downloads}" \
+    "${max_concurrent_uploads}" \
+    "$insecure_registries" \
+    "$registry_mirror"
+
   log_in "$username" "$password" "$registry"
 
   docker_pull "$image_name"


### PR DESCRIPTION
The 'in' script performs no Docker operations when `skip_download` is set to true, so it does not make sense to start dockerd in that case. Considering that one usually sets `skip_download: true` to speed up the implicit "get" of the "put" operation, i think it's a meaningful optimization.