### PR TITLE
Add the ability to use regexp for tags in docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY assets/ /assets
 RUN go build -o /assets/check github.com/concourse/docker-image-resource/cmd/check
 RUN go build -o /assets/print-metadata github.com/concourse/docker-image-resource/cmd/print-metadata
 RUN go build -o /assets/ecr-login github.com/concourse/docker-image-resource/vendor/github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cmd
+RUN apk add --update gcc g++
 RUN set -e; \
     for pkg in $(go list ./...); do \
       go test -o "/tests/$(basename $pkg).test" -c $pkg; \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
 
 * `tag`: *Optional.* The tag to track. Defaults to `latest`.
 
+* `regex`: *Optional.* Filter image tags using this regex.
+
+  /!\ If both tag and regexp are here, defaults to `regexp`
+  If both are empty, default to `latest`
+
+  Example :
+  ``` yaml
+  - name: etcd.repository
+    type: docker-image
+    source:
+      repository: containers.io/coreos/etcd
+      regex: "^prod-\\S*$"
+  ```
+
 * `username`: *Optional.* The username to authenticate with when pushing.
 
 * `password`: *Optional.* The password to use when authenticating.

--- a/assets/in
+++ b/assets/in
@@ -29,7 +29,11 @@ registry_mirror=$(jq -r '.source.registry_mirror // ""' < $payload)
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)
 repository="$(jq -r '.source.repository // ""' < $payload)"
-tag="$(jq -r '.source.tag // "latest"' < $payload)"
+if [[ ! -z $(jq -r '.version.tag' < ${payload}) ]]; then
+  tag="$(jq -r '.version.tag' < ${payload})"
+else
+  tag="$(jq -r '.source.tag // "latest"' < ${payload})"
+fi
 ca_certs=$(jq -r '.source.ca_certs // []' < $payload)
 client_certs=$(jq -r '.source.client_certs // []' < $payload)
 max_concurrent_downloads=$(jq -r '.source.max_concurrent_downloads // 3' < $payload)

--- a/cmd/check/models.go
+++ b/cmd/check/models.go
@@ -1,10 +1,18 @@
 package main
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+)
+
+var VersionRegex = regexp.MustCompile("^\\S*$")
 
 type Source struct {
 	Repository         string          `json:"repository"`
 	Tag                json.Number     `json:"tag"`
+	Regex              string          `json:"regex"`
 	Username           string          `json:"username"`
 	Password           string          `json:"password"`
 	InsecureRegistries []string        `json:"insecure_registries"`
@@ -18,7 +26,47 @@ type Source struct {
 }
 
 type Version struct {
-	Digest string `json:"digest"`
+	Digest  string           `json:"digest,omitempty"`
+	Tag     string           `json:"tag,omitempty"`
+}
+
+// CheckedVersion parses the given version and returns a new
+// Version.
+func CheckedVersion(v string) (string, error) {
+	matches := VersionRegex.FindStringSubmatch(v)
+	if matches == nil {
+		fmt.Errorf("Malformed version: %s", v)
+		return v, nil
+	}
+	fmt.Fprintf(os.Stderr, "** matches : %s\n", matches)
+	segments := matches[0]
+
+	return segments, nil
+}
+
+func ParsedVersion(raw string) (string error) {
+	v := raw
+	err := ParseGroup(v)
+	return err
+}
+
+func ParseGroup(v string) (err error) {
+	match := VersionRegex.FindStringSubmatch(v)
+
+	if match == nil {
+		return fmt.Errorf("Tag %s filtered by regex", v)
+	}
+	switch len(match) {
+	case 1:
+		v, err = CheckedVersion(match[0])
+	case 2:
+		v, err = CheckedVersion(match[1])
+	case 3:
+		v, err = CheckedVersion(fmt.Sprintf("%s-%s", match[1], match[2]))
+	default:
+		v, err = CheckedVersion(fmt.Sprintf("%s-%s+%s", match[1], match[2], match[3]))
+	}
+	return
 }
 
 type CheckRequest struct {
@@ -37,4 +85,24 @@ type ClientCertKey struct {
 	Domain string `json:"domain"`
 	Cert   string `json:"cert"`
 	Key    string `json:"key"`
+}
+
+type V1Compatibility struct {
+	ID              string `json:"id"`
+	Parent          string `json:"parent"`
+	Created         string `json:"created"`
+}
+type ManifestResponse struct {
+	Name         string `json:"name"`
+	Tag          string `json:"tag"`
+	Architecture string `json:"architecture"`
+
+	FsLayers []struct {
+		BlobSum string `json:"blobSum"`
+	} `json:"fsLayers"`
+
+	History []struct {
+		V1CompatibilityRaw string `json:"v1Compatibility"`
+		V1Compatibility V1Compatibility
+	} `json:"history"`
 }


### PR DESCRIPTION
In Leboncoin we started using Concourse for our CD but we needed to make some adjustment for some resources, so here is the change we had to do for the docker-image-resource.

For tools like kubernetes which can be setup not to force pull if some image with the same name is already present,
it can be useful to just use a regexp on a tag and select the latest tag matching the regexp.