### PR TITLE
set Docker build arg with contents of arbitrary file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,12 @@ RUN set -e; \
       $test -ginkgo.v; \
     done
 
+# stage: shelltests
+FROM resource AS shelltests
+ADD . /docker-image-resource
+WORKDIR /docker-image-resource/tests/shell-tests
+ADD . https://raw.githubusercontent.com/kward/shunit2/v2.1.7/shunit2
+RUN ./test.sh
+
 # final output stage
 FROM resource

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ COPY assets/ /assets
 RUN go build -o /assets/check github.com/concourse/docker-image-resource/cmd/check
 RUN go build -o /assets/print-metadata github.com/concourse/docker-image-resource/cmd/print-metadata
 RUN go build -o /assets/ecr-login github.com/concourse/docker-image-resource/vendor/github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cmd
-ENV CGO_ENABLED 1
 RUN set -e; \
     for pkg in $(go list ./...); do \
       go test -o "/tests/$(basename $pkg).test" -c $pkg; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,8 @@ RUN set -e; \
 # stage: shelltests
 FROM resource AS shelltests
 ADD . /docker-image-resource
-WORKDIR /docker-image-resource/tests/shell-tests
-ADD . https://raw.githubusercontent.com/kward/shunit2/v2.1.7/shunit2
-RUN ./test.sh
+RUN wget --directory-prefix  /docker-image-resource/tests/shell-tests/ https://raw.githubusercontent.com/kward/shunit2/v2.1.7/shunit2
+RUN cd /docker-image-resource/tests/shell-tests/ && ./test.sh
 
 # final output stage
 FROM resource

--- a/README.md
+++ b/README.md
@@ -171,6 +171,21 @@ version is the image's digest.
     CI_BUILD_ID: concourse-$BUILD_ID
   ```
 
+  There may be times when the contents of an arbitrary file need to be used
+  as a build arg and `build_args_file` is not sufficient. In this case, there
+  is a special form of `build_args` which uses the token `from_file` to support
+  the passing of files whose contents should be read into an arbitrary build_arg:
+
+  Example:
+
+  ```yaml
+  build_args:
+    NORMAL_BUILD_ARG: hello
+    from_file:
+      FROM_FOO_FILE: some/path/to/foo.txt
+      BAR_FILE_CONTENTS: another/path/to/bar.csv
+  ```
+
 * `build_args_file`: *Optional.* Path to a JSON file containing Docker
   build-time variables.
 
@@ -324,7 +339,7 @@ wget --directory-prefix ./tests/shell-tests/ https://raw.githubusercontent.com/k
 Invoke the tests from this repo's `./tests/shell-tests/` directory:
 
 ```sh
-cd tests/shell-tests/ && ./test.sh
+cd ./tests/shell-tests/ && ./test.sh
 ```
 
 Note that these tests are also executed during `docker build...`.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,22 @@ resources:
   ...
 ```
 
+#### Running the shell tests locally
+
+Download [shunit](https://github.com/kward/shunit2) to this repo's `./tests/shell-tests/` directory:
+
+```sh
+wget --directory-prefix ./tests/shell-tests/ https://raw.githubusercontent.com/kward/shunit2/v2.1.7/shunit2
+```
+
+Invoke the tests from this repo's `./tests/shell-tests/` directory:
+
+```sh
+cd tests/shell-tests/ && ./test.sh
+```
+
+Note that these tests are also executed during `docker build...`.
+
 ### Contributing
 
 Please make all pull requests to the `master` branch and ensure tests pass

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -93,7 +93,7 @@ start_docker() {
   declare -fx try_start
   trap stop_docker EXIT
 
-  if ! timeout -t ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
+  if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
     echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
     return 1
   fi

--- a/assets/out
+++ b/assets/out
@@ -8,6 +8,8 @@ exec 1>&2 # redirect all output to stderr for logging
 
 source $(dirname $0)/common.sh
 
+source $(dirname $0)/resource-based-build-args.sh
+
 source=$1
 
 if [ -z "$source" ]; then
@@ -63,7 +65,14 @@ fi
 tag_prefix=$(jq -r '.params.tag_prefix // ""' < $payload)
 additional_tags=$(jq -r '.params.additional_tags // ""' < $payload)
 need_tag_as_latest=$(jq -r '.params.tag_as_latest // "false"' < $payload)
-build_args=$(jq -r '.params.build_args // {}' < $payload)
+raw_build_args=$(jq -r '.params.build_args // {}' < $payload)
+build_args=""
+if [[ $(has_from_file "$raw_build_args") ]]
+then
+  build_args=$(elevate_from_file_kvps "$raw_build_args")
+else
+  build_args=raw_build_args
+fi
 build_args_file=$(jq -r '.params.build_args_file // ""' < $payload)
 
 

--- a/assets/out
+++ b/assets/out
@@ -67,7 +67,7 @@ additional_tags=$(jq -r '.params.additional_tags // ""' < $payload)
 need_tag_as_latest=$(jq -r '.params.tag_as_latest // "false"' < $payload)
 raw_build_args=$(jq -r '.params.build_args // {}' < $payload)
 build_args=""
-if [[ $(has_from_file "$raw_build_args") ]]
+if [[ $(has_from_file "$raw_build_args") = true ]]
 then
   build_args=$(elevate_from_file_kvps "$raw_build_args")
 else

--- a/assets/out
+++ b/assets/out
@@ -71,7 +71,7 @@ if [[ $(has_from_file "$raw_build_args") ]]
 then
   build_args=$(elevate_from_file_kvps "$raw_build_args")
 else
-  build_args=raw_build_args
+  build_args=$raw_build_args
 fi
 build_args_file=$(jq -r '.params.build_args_file // ""' < $payload)
 

--- a/assets/resource-based-build-args.sh
+++ b/assets/resource-based-build-args.sh
@@ -35,7 +35,6 @@ elevate_from_file_kvps() {
     rejsoned+='"'
     rejsoned+="${kvpmap[$key]}"
     rejsoned+='"'
-      echo "$key = ${kvpmap[$key]}" >> ./hopefully
   done
 
   rejsoned+='}'

--- a/assets/resource-based-build-args.sh
+++ b/assets/resource-based-build-args.sh
@@ -1,8 +1,13 @@
 #! usr/bin/env bash
 
 has_from_file() {
-  result=$(echo "$1" | jq 'has("from_file")')
-  echo "$result"
+  if [[ -z "$1" ]]
+  then
+    echo false
+  else
+    result=$(echo "$1" | jq 'has("from_file")')
+    echo "$result"
+  fi
 }
 
 elevate_from_file_kvps() {

--- a/assets/resource-based-build-args.sh
+++ b/assets/resource-based-build-args.sh
@@ -19,10 +19,10 @@ elevate_from_file_kvps() {
   done
 
   rejsoned='{'
-
+  has_skipped_first_line=false
   for key in "${!kvpmap[@]}"
   do
-    if [[ -n "$has_skipped_first_line" ]]
+    if [[ "$has_skipped_first_line" = true ]]
     then
       rejsoned+=','
     else

--- a/assets/resource-based-build-args.sh
+++ b/assets/resource-based-build-args.sh
@@ -39,7 +39,9 @@ elevate_from_file_kvps() {
 
   rejsoned+='}'
 
-  result="$rejsoned"
+  no_more_from_file=$(echo "$1" | jq 'del(.from_file)')
+
+  result=$(echo "$no_more_from_file" "$rejsoned" | jq -c -s add)
 
   echo "$result"
 }

--- a/assets/resource-based-build-args.sh
+++ b/assets/resource-based-build-args.sh
@@ -1,0 +1,12 @@
+#! usr/bin/env bash
+
+has_build_args() {
+  result=$(echo "$1" | jq 'map_values(has("build_args")).params')
+  if [[ "$result" == "true" ]]; then echo "0"; else echo "1"; fi
+}
+
+has_from_file() {
+  result=$(echo "$1" | jq '.params | map_values(has("from_file")).build_args')
+  if [[ "$result" == "true" ]]; then echo "0"; else echo "1"; fi
+}
+

--- a/assets/resource-based-build-args.sh
+++ b/assets/resource-based-build-args.sh
@@ -1,12 +1,47 @@
 #! usr/bin/env bash
 
-has_build_args() {
-  result=$(echo "$1" | jq 'map_values(has("build_args")).params')
-  if [[ "$result" == "true" ]]; then echo "0"; else echo "1"; fi
+has_from_file() {
+  result=$(echo "$1" | jq 'has("from_file")')
+  echo "$result"
 }
 
-has_from_file() {
-  result=$(echo "$1" | jq '.params | map_values(has("from_file")).build_args')
-  if [[ "$result" == "true" ]]; then echo "0"; else echo "1"; fi
+elevate_from_file_kvps() {
+  declare -A kvpmap
+
+  while IFS=" " read -r key value
+  do
+    kvpmap["$key"]="$value"
+  done < <(echo "$1" | jq -r '.from_file | to_entries | .[] | .key+" "+.value')
+
+  for key in "${!kvpmap[@]}"
+  do
+    kvpmap["$key"]=$(cat "${kvpmap["$key"]}")
+  done
+
+  rejsoned='{'
+
+  for key in "${!kvpmap[@]}"
+  do
+    if [[ -n "$has_skipped_first_line" ]]
+    then
+      rejsoned+=','
+    else
+      has_skipped_first_line=true
+    fi
+    rejsoned+='"'
+    rejsoned+="$key"
+    rejsoned+='"'
+    rejsoned+=':'
+    rejsoned+='"'
+    rejsoned+="${kvpmap[$key]}"
+    rejsoned+='"'
+      echo "$key = ${kvpmap[$key]}" >> ./hopefully
+  done
+
+  rejsoned+='}'
+
+  result="$rejsoned"
+
+  echo "$result"
 }
 

--- a/cmd/print-metadata/main_test.go
+++ b/cmd/print-metadata/main_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
 	"runtime"
 	"syscall"
 
@@ -23,9 +22,8 @@ type imageMetadata struct {
 
 var _ = Describe("print-metadata", func() {
 	var (
-		cmd             *exec.Cmd
-		userFile        *os.File
-		currentUserName string
+		cmd      *exec.Cmd
+		userFile *os.File
 
 		metadata imageMetadata
 	)
@@ -60,25 +58,21 @@ var _ = Describe("print-metadata", func() {
 
 		Context("when password file contains current user", func() {
 			BeforeEach(func() {
-				currentUser, err := user.Current()
-				Expect(err).NotTo(HaveOccurred())
-
-				currentUserName = currentUser.Username
 				currentUsedID := syscall.Getuid()
 
-				_, err = userFile.WriteString(fmt.Sprintf(
+				_, err := userFile.WriteString(fmt.Sprintf(
 					"%s:*:%d:%d:System Administrator:/var/%s:/bin/sh\n",
-					currentUserName,
+					"some-user",
 					currentUsedID,
 					currentUsedID,
-					currentUserName,
+					"some-user",
 				))
 				Expect(err).NotTo(HaveOccurred())
 				userFile.Sync()
 			})
 
 			It("sets current user in metadata", func() {
-				Expect(metadata.User).To(Equal(currentUserName))
+				Expect(metadata.User).To(Equal("some-user"))
 			})
 		})
 	})

--- a/tests/shell-tests/test.sh
+++ b/tests/shell-tests/test.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+
+testHasBuildArgsWithNoBuildArgsReturnsFalse() {
+  input='{"params":{"foo":"bar"}}'
+  actual=$(has_build_args "$input")
+  assertFalse "$actual"
+}
+
+testHasBuildArgsWithBuildArgsReturnsTrue() {
+  input='{"params":{"build_args":{"foo":"bar"}}}'
+  actual=$(has_build_args "$input")
+  assertTrue "$actual"
+}
+
+testHasFromFileWithNoFromFileReturnsFalse() {
+  input='{"params":{"build_args":{"foo":"bar"}}}'
+  actual=$(has_from_file "$input")
+  assertFalse "$actual"
+}
+
+testHasFromFileWithFromFileReturnsTrue() {
+  input='{"params":{"build_args":{"from_file":{"foo":"bar"}}}}'
+  actual=$(has_from_file "$input")
+  assertTrue "$actual"
+}
+
+oneTimeSetUp() {
+  . ../../assets/resource-based-build-args.sh
+}
+
+. ./shunit2
+

--- a/tests/shell-tests/test.sh
+++ b/tests/shell-tests/test.sh
@@ -14,14 +14,18 @@ testHasFromFileWithFromFileReturnsTrue() {
   assertTrue "$actual"
 }
 
-testFromSingleFileContentsReadIntoKVP() {
-  tempfile=$(mktemp)
-  echo "qux" >> "$tempfile"
+testOnlyFileContentsReadIntoKVP() {
+  tempfile1=$(mktemp)
+  tempfile2=$(mktemp)
+  echo "qux" >> "$tempfile1"
+  echo "eggs" >> "$tempfile2"
   full_input='{"params":{"build_args":{"from_file":{"foo":"'
-  full_input+="$tempfile"
+  full_input+="$tempfile1"
+  full_input+='","spam":"'
+  full_input+="$tempfile2"
   full_input+='"}}}}'
   build_args=$(buildArgExtractionCopiedFromProd "$full_input")
-  expected='{"foo":"qux"}'
+  expected='{"spam":"eggs","foo":"qux"}'
   actual=$(elevate_from_file_kvps "$build_args")
   assertEquals "$expected" "$actual"
 }

--- a/tests/shell-tests/test.sh
+++ b/tests/shell-tests/test.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+testHasFromFileWithNoBuildArgsReturnsFalse() {
+  full_input='{"params":{"foo":"bar"}}'
+  build_args=$(buildArgExtractionCopiedFromProd "$full_input")
+  actual=$(has_from_file "$build_args")
+  assertFalse "$actual"
+}
+
 testHasFromFileWithNoFromFileReturnsFalse() {
   full_input='{"params":{"build_args":{"foo":"bar"}}}'
   build_args=$(buildArgExtractionCopiedFromProd "$full_input")
@@ -12,6 +19,21 @@ testHasFromFileWithFromFileReturnsTrue() {
   build_args=$(buildArgExtractionCopiedFromProd "$full_input")
   actual=$(has_from_file "$build_args")
   assertTrue "$actual"
+}
+
+testHasFromFileWithNullReturnsFalse() {
+  actual=$(has_from_file "$empty_var")
+  assertFalse "$actual"
+}
+
+testHasFromFileWithEmptyStringReturnsFalse() {
+  actual=$(has_from_file "")
+  assertFalse "$actual"
+}
+
+testHasFromFileWithEmptyObjectReturnsFalse() {
+  actual=$(has_from_file "{}")
+  assertFalse "$actual"
 }
 
 testOnlyFileContentsReadIntoKVP() {

--- a/tests/shell-tests/test.sh
+++ b/tests/shell-tests/test.sh
@@ -47,7 +47,7 @@ testOnlyFileContentsReadIntoKVP() {
   full_input+="$tempfile2"
   full_input+='"}}}}'
   build_args=$(buildArgExtractionCopiedFromProd "$full_input")
-  expected='{"spam":"eggs","foo":"qux"}'
+  expected='{"foo":"qux","spam":"eggs"}'
   actual=$(elevate_from_file_kvps "$build_args")
   assertEquals "$expected" "$actual"
 }

--- a/tests/shell-tests/test.sh
+++ b/tests/shell-tests/test.sh
@@ -30,6 +30,18 @@ testOnlyFileContentsReadIntoKVP() {
   assertEquals "$expected" "$actual"
 }
 
+testFileContentsMergeWithOtherBuildArgs() {
+  tempfile=$(mktemp)
+  echo "qux" >> "$tempfile"
+  full_input='{"params":{"build_args":{"spam":"eggs","from_file":{"foo":"'
+  full_input+="$tempfile"
+  full_input+='"}}}}'
+  build_args=$(buildArgExtractionCopiedFromProd "$full_input")
+  expected='{"spam":"eggs","foo":"qux"}'
+  actual=$(elevate_from_file_kvps "$build_args")
+  assertEquals "$expected" "$actual"
+}
+
 oneTimeSetUp() {
   . ../../assets/resource-based-build-args.sh
 }


### PR DESCRIPTION
This PR fixes the specific behavior raised in https://github.com/concourse/docker-image-resource/issues/203 (*semver resource not usable as build_arg*). More generally, it supports setting a Docker build arg with the contents of an arbitrary file.

It is useful when the contents of a file cannot be coerced into the form necessary for `build_args_file`.