### PR TITLE
Print a nicer error message when the image cannot be found

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -90,7 +90,7 @@ func main() {
 	latestManifestURL, err := ub.BuildManifestURL(taggedRef)
 	fatalIf("failed to build latest manifest URL", err)
 
-	latestDigest, foundLatest := fetchDigest(client, latestManifestURL)
+	latestDigest, foundLatest := fetchDigest(client, latestManifestURL, request.Source.Repository, tag)
 
 	if request.Version.Digest != "" {
 		digestRef, err := reference.WithDigest(namedRef, digest.Digest(request.Version.Digest))
@@ -99,7 +99,7 @@ func main() {
 		cursorManifestURL, err := ub.BuildManifestURL(digestRef)
 		fatalIf("failed to build manifest URL", err)
 
-		cursorDigest, foundCursor := fetchDigest(client, cursorManifestURL)
+		cursorDigest, foundCursor := fetchDigest(client, cursorManifestURL, request.Source.Repository, tag)
 
 		if foundCursor && cursorDigest != latestDigest {
 			response = append(response, Version{cursorDigest})
@@ -113,7 +113,7 @@ func main() {
 	json.NewEncoder(os.Stdout).Encode(response)
 }
 
-func fetchDigest(client *http.Client, manifestURL string) (string, bool) {
+func fetchDigest(client *http.Client, manifestURL, repository, tag string) (string, bool) {
 	manifestRequest, err := http.NewRequest("GET", manifestURL, nil)
 	fatalIf("failed to build manifest request", err)
 	manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
@@ -123,13 +123,12 @@ func fetchDigest(client *http.Client, manifestURL string) (string, bool) {
 	fatalIf("failed to fetch manifest", err)
 
 	defer manifestResponse.Body.Close()
-
 	if manifestResponse.StatusCode == http.StatusNotFound {
 		return "", false
 	}
 
 	if manifestResponse.StatusCode != http.StatusOK {
-		fatal("failed to fetch digest: " + manifestResponse.Status)
+		fatal(fmt.Sprintf("failed to fetch digest for image '%s:%s': %s\ndoes the image exist?", repository, tag, manifestResponse.Status))
 	}
 
 	digest := manifestResponse.Header.Get("Docker-Content-Digest")

--- a/tests/check_test.go
+++ b/tests/check_test.go
@@ -1,0 +1,74 @@
+package docker_image_resource_test
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"encoding/json"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Check", func() {
+	BeforeEach(func() {
+		os.Setenv("PATH", "/docker-image-resource/tests/fixtures/bin:"+os.Getenv("PATH"))
+		os.Setenv("SKIP_PRIVILEGED", "true")
+		os.Setenv("LOG_FILE", "/dev/stderr")
+	})
+
+	check := func(params map[string]interface{}) *gexec.Session {
+		command := exec.Command("/opt/resource/check", "/tmp")
+
+		resourceInput, err := json.Marshal(params)
+		Expect(err).ToNot(HaveOccurred())
+
+		command.Stdin = bytes.NewBuffer(resourceInput)
+
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
+		<-session.Exited
+		return session
+	}
+
+	It("errors when image is unknown", func() {
+		repository := "kjlasdfaklklj12"
+		tag := "latest"
+		session := check(map[string]interface{}{
+			"source": map[string]interface{}{
+				"repository": repository,
+			},
+		})
+
+		expectedStringInError := fmt.Sprintf("%s:%s", repository, tag)
+		Expect(session.Err).To(gbytes.Say(expectedStringInError))
+	})
+
+	It("errors when image:tag is unknown", func() {
+		repository := "kjlasdfaklklj12"
+		tag := "aklsdf123"
+		session := check(map[string]interface{}{
+			"source": map[string]interface{}{
+				"repository": repository,
+				"tag": tag,
+			},
+		})
+
+		expectedStringInError := fmt.Sprintf("%s:%s", repository, tag)
+		Expect(session.Err).To(gbytes.Say(expectedStringInError))
+	})
+
+	It("prints out the digest for a existent image", func() {
+		session := check(map[string]interface{}{
+			"source": map[string]interface{}{
+				"repository": "alpine",
+			},
+		})
+
+		Expect(session.Out).To(gbytes.Say(`{"digest":`))
+	})
+})


### PR DESCRIPTION
Fixes https://github.com/concourse/concourse/issues/980

When a user of Concourse accidentally puts a bad image name, we (the maintainers) of Concourse gets questions like "why is my pipeline broken? I did not change anything" since its not clear that the image they specified is bad.

```
- name: build
  - task: build
    config:
      platform: linux
      image_resource:
        type: docker-image
        source:
          repository: Ubuntu is an ancient african word, meaning I can't configure Debian
          tag: latest
     .. ... ..
```

instead of seeing in the UI

```
error: check failed with exit status '1':
failed to fetch digest: 401 Unauthorized
```

the user would now see

```
error: check failed with exit status '1':
failed to fetch digest for image 'Ubuntu is an ancient african word, meaning I can't configure Debian:latest': 401 Unauthorized
does the image exist?
```