### PR TITLE
support experimental option and buildkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
  * `max_concurrent_uploads`: *Optional.* Maximum concurrent uploads.
 
    Limits the number of concurrent upload threads.
+  
+  * `experimental`: *Optional.* Use Dockerd experimental option
 
 ## Behavior
 
@@ -259,6 +261,8 @@ version is the image's digest.
 
 * `target_name`: *Optional.*  Specify the name of the target build stage. 
   Only supported for multi-stage Docker builds
+* `buildkit`: *Optional.*  Default`false`. If true use　Buildkit. 
+  In order to use this option you need to enable experimental.
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ version is the image's digest.
 
 * `target_name`: *Optional.*  Specify the name of the target build stage. 
   Only supported for multi-stage Docker builds
-* `buildkit`: *Optional.*  Default`false`. If true use　Buildkit. 
+* `buildkit`: *Optional.* Default `false`. If `true`, use Buildkit. 
   In order to use this option you need to enable experimental.
 
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -73,6 +73,9 @@ start_docker() {
   if [ -n "$4" ]; then
     server_args="${server_args} --registry-mirror $4"
   fi
+  if [ "$5" = "true" ]; then
+    server_args="${server_args} --experimental"
+  fi
 
   try_start() {
     dockerd --data-root /scratch/docker ${server_args} >$LOG_FILE 2>&1 &

--- a/assets/in
+++ b/assets/in
@@ -34,6 +34,7 @@ ca_certs=$(jq -r '.source.ca_certs // []' < $payload)
 client_certs=$(jq -r '.source.client_certs // []' < $payload)
 max_concurrent_downloads=$(jq -r '.source.max_concurrent_downloads // 3' < $payload)
 max_concurrent_uploads=$(jq -r '.source.max_concurrent_uploads // 3' < $payload)
+experimental=$(jq -r '.source.experimental // false' < $payload)
 
 export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // ""' < $payload)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // ""' < $payload)
@@ -62,7 +63,8 @@ if [ "$skip_download" = "false" ]; then
     "${max_concurrent_downloads}" \
     "${max_concurrent_uploads}" \
     "$insecure_registries" \
-    "$registry_mirror"
+    "$registry_mirror" \
+    "$experimental"
 
   log_in "$username" "$password" "$registry"
 

--- a/assets/out
+++ b/assets/out
@@ -34,6 +34,7 @@ ca_certs=$(jq -r '.source.ca_certs // []' < $payload)
 client_certs=$(jq -r '.source.client_certs // []' < $payload)
 max_concurrent_downloads=$(jq -r '.source.max_concurrent_downloads // 3' < $payload)
 max_concurrent_uploads=$(jq -r '.source.max_concurrent_uploads // 3' < $payload)
+experimental=$(jq -r '.source.experimental // false' < $payload)
 
 export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // ""' < $payload)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // ""' < $payload)
@@ -51,7 +52,9 @@ start_docker \
 	"${max_concurrent_downloads}" \
 	"${max_concurrent_uploads}" \
 	"$insecure_registries" \
-	"$registry_mirror"
+	"$registry_mirror" \
+	"$experimental"
+
 log_in "$username" "$password" "$registry"
 
 tag_source=$(jq -r '.source.tag // "latest"' < $payload)
@@ -67,7 +70,11 @@ build_args=$(jq -r '.params.build_args // {}' < $payload)
 build_args_file=$(jq -r '.params.build_args_file // ""' < $payload)
 labels=$(jq -r '.params.labels // {}' < $payload)
 labels_file=$(jq -r '.params.labels_file // ""' < $payload)
+buidkit=$(jq -r '.params.buildkit // false' < $payload)
 
+if [ "$buidkit" = "true" ]; then
+  export DOCKER_BUILDKIT=1
+fi
 
 tag_name=""
 if [ -n "$tag_params" ]; then

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -303,6 +303,22 @@ var _ = Describe("Out", func() {
 		})
 	})
 
+	Context("when configured with a experimental", func() {
+		It("passes it to dockerd", func() {
+			session := put(map[string]interface{}{
+				"source": map[string]interface{}{
+					"repository":   "test",
+					"experimental": "true",
+				},
+				"params": map[string]interface{}{
+					"build": "/docker-image-resource/tests/fixtures/build",
+				},
+			})
+
+			Expect(session.Err).To(gbytes.Say(dockerd(`.*--experimental.*`)))
+		})
+	})
+
 	Context("when configured with a target build stage", func() {
 		It("passes it to dockerd", func() {
 			session := put(map[string]interface{}{


### PR DESCRIPTION
added a setting to enable buildkit which is Docker 's new Image builder.
In order to use buildkit you need to enable dockerd's experimental.

The following sample confirms the operation.
```
---
resource_types:
- name: buildkit-on
  type: docker-image
  privileged: true
  source:
    repository: inttt/docker-image-resource
    tag: latest

resources:
- name: git-resource
  type: git
  source:
    uri: https://github.com/int-tt/docker-image-resource
    branch: feat-support-buildkit

- name: docker-resource-image
  type: buildkit-on
  source:
    repository: inttt/docker-image-resource
    experimental: true

jobs:
- name: build-rootfs
  plan:
  - get: git-resource
  - put: docker-resource-image
    params:
      build: git-resource
      buildkit: true
```

This gives you the benefit of faster build by buildkit :)
https://github.com/moby/buildkit