### PR TITLE
Allow Build to continue if cache pull fails

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -197,7 +197,7 @@ docker_pull() {
 
     if docker pull "$1"; then
       printf "\nSuccessfully pulled ${GREEN}%s${NC}.\n\n" "$1"
-      return
+      return 0
     fi
 
     echo
@@ -206,5 +206,5 @@ docker_pull() {
   done
 
   printf "\n${RED}Failed to pull image %s.${NC}" "$1"
-  exit 1
+  return 1
 }

--- a/assets/out
+++ b/assets/out
@@ -147,7 +147,7 @@ elif [ -n "$build" ]; then
   cache_from_args=()
 
   if [ "$cache" = "true" ]; then
-    docker_pull "${repository}:${cache_tag}"
+    docker_pull "${repository}:${cache_tag}" && 
     cache_from_args+=("--cache-from ${repository}:${cache_tag}")
   fi
 

--- a/assets/out
+++ b/assets/out
@@ -147,8 +147,9 @@ elif [ -n "$build" ]; then
   cache_from_args=()
 
   if [ "$cache" = "true" ]; then
-    docker_pull "${repository}:${cache_tag}" && 
-    cache_from_args+=("--cache-from ${repository}:${cache_tag}")
+    if docker_pull "${repository}:${cache_tag}"; then
+      cache_from_args+=("--cache-from ${repository}:${cache_tag}")
+    fi
   fi
 
   if [ -n "$cache_from" ]; then

--- a/tests/fixtures/bin/docker
+++ b/tests/fixtures/bin/docker
@@ -14,3 +14,7 @@ fi
 if [ "$1" == "info" ] && [ -f /tmp/docker_failing ]; then
     exit 1
 fi
+
+if [ "$1" == "pull" ] && [ "$2" == "broken-repo:latest" ]; then
+    exit 1
+fi

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -539,6 +539,38 @@ var _ = Describe("Out", func() {
 		})
 	})
 
+	Context("when cache is specified are specified", func() {
+		It("adds argument to cache_from", func() {
+			session := put(map[string]interface{}{
+				"source": map[string]interface{}{
+					"repository": "test",
+				},
+				"params": map[string]interface{}{
+					"build":      "/docker-image-resource/tests/fixtures/build",
+					"cache":      "true",
+				},
+			})
+
+			Expect(session.Err).To(gbytes.Say(dockerarg(`--cache-from`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`test:latest`)))
+		})
+
+		It("does not add cache_from if pull fails", func() {
+			session := put(map[string]interface{}{
+				"source": map[string]interface{}{
+					"repository": "test",
+				},
+				"params": map[string]interface{}{
+					"build":      "/docker-image-resource/tests/fixtures/broken",
+					"cache":      "true",
+				},
+			})
+
+			Expect(session.Err).ToNot(gbytes.Say(dockerarg(`--cache-from`)))
+			Expect(session.Err).ToNot(gbytes.Say(dockerarg(`test:latest`)))
+		})
+	});
+
 	Context("when cache_from images are specified", func() {
 		BeforeEach(func() {
 			os.Mkdir("/tmp/cache_from_1", os.ModeDir)
@@ -564,7 +596,7 @@ var _ = Describe("Out", func() {
 			session := put(map[string]interface{}{
 				"source": map[string]interface{}{
 					"repository": "test",
-				},
+				}, 
 				"params": map[string]interface{}{
 					"build":      "/docker-image-resource/tests/fixtures/build",
 					"cache_from": []string{"cache_from_1", "cache_from_2"},

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -566,7 +566,7 @@ var _ = Describe("Out", func() {
 			})
 
 			Expect(session.Err).ToNot(gbytes.Say(dockerarg(`--cache-from`)))
-			Expect(session.Err).ToNot(gbytes.Say(dockerarg(`broken-repo:latest`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`broken-repo:latest`)))
 			Expect(session.Err).To(gbytes.Say(dockerarg(`build`)))
 
 		})

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -550,7 +550,6 @@ var _ = Describe("Out", func() {
 					"cache":      "true",
 				},
 			})
-
 			Expect(session.Err).To(gbytes.Say(dockerarg(`--cache-from`)))
 			Expect(session.Err).To(gbytes.Say(dockerarg(`test:latest`)))
 		})
@@ -558,16 +557,18 @@ var _ = Describe("Out", func() {
 		It("does not add cache_from if pull fails", func() {
 			session := put(map[string]interface{}{
 				"source": map[string]interface{}{
-					"repository": "test",
+					"repository": "broken-repo",
 				},
 				"params": map[string]interface{}{
-					"build":      "/docker-image-resource/tests/fixtures/broken",
+					"build":     "/docker-image-resource/tests/fixtures/build",
 					"cache":      "true",
 				},
 			})
 
 			Expect(session.Err).ToNot(gbytes.Say(dockerarg(`--cache-from`)))
-			Expect(session.Err).ToNot(gbytes.Say(dockerarg(`test:latest`)))
+			Expect(session.Err).ToNot(gbytes.Say(dockerarg(`broken-repo:latest`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`build`)))
+
 		})
 	});
 


### PR DESCRIPTION
##Problem
Builds would fail if the cached pull failed, this caused problems when first running an automated build and no image exists in the repository.
## Solution
Stop `--cache-from` being added if the docker pull fails

## Testing
Added tests for basic caching parameter and what happens if it fails to pull

Fixes #222 