### PR TITLE
Multi target repo for build task

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,7 @@ version is the image's digest.
 * `target_name`: *Optional.*  Specify the name of the target build stage.
   Only supported for multi-stage Docker builds
 
-* `repository_file`: *Optional.* Override source repository. The value should be a path to a file containing the name
-  of the repository path.
+* `repository_file`: *Optional.* Override source repository. The value should be a path to a file containing the repository path.
 
 * `repository`: *Optional.* Override source repository. Value used only if `repository_file` is unset
 

--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ version is the image's digest.
 
 * `build_args`: *Optional.* A map of Docker build-time variables. These will be
   available as environment variables during the Docker build.
-  
+
   While not stored in the image layers, they are stored in image metadata and
   so it is recommend to avoid using these to pass secrets into the build
   context. In multi-stage builds `ARG`s in earlier stages will not be copied
   to the later stages, or in the metadata of the final stage.
-  
+
   The
   [build metadata](https://concourse-ci.org/implementing-resources.html#resource-metadata)
   environment variables provided by Concourse will be expanded in the values
@@ -259,8 +259,13 @@ version is the image's digest.
   prepended with this string. This is useful for adding `v` in front of version
   numbers.
 
-* `target_name`: *Optional.*  Specify the name of the target build stage. 
+* `target_name`: *Optional.*  Specify the name of the target build stage.
   Only supported for multi-stage Docker builds
+
+* `repository_file`: *Optional.* Override source repository. The value should be a path to a file containing the name
+  of the repository path.
+
+* `repository`: *Optional.* Override source repository. Value used only if `repository_file` is unset
 
 
 ## Example

--- a/assets/out
+++ b/assets/out
@@ -39,6 +39,23 @@ export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // ""' < $payload)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // ""' < $payload)
 export AWS_SESSION_TOKEN=$(jq -r '.source.aws_session_token // ""' < $payload)
 
+# Repository passed as parameter
+# Replicating behaviour of tag_file
+params_repository=$(jq -r '.params.repository_file // ""' < $payload)
+
+if [ -z "$params_repository" ]; then
+  params_repository=$(jq -r '.params.repository // ""' < $payload)
+fi
+
+if [ -n "$params_repository" ]; then
+  if [ -f "$params_repository" ];then
+    repository="$(cat $params_repository)"
+  else
+      repository="$params_repository"
+  fi
+fi
+
+
 if private_registry "${repository}" ; then
   registry="$(extract_registry "${repository}")"
 else
@@ -241,7 +258,7 @@ elif [ -n "$build" ]; then
       # see https://github.com/moby/moby/pull/32677
       # and https://github.com/awslabs/amazon-ecr-credential-helper/issues/9
       docker pull "${ecr_image}"
-    done    
+    done
   fi
 
   docker build -t "${repository}:${tag_name}" "${target[@]}" "${expanded_build_args[@]}" "${expanded_labels[@]}" -f "$dockerfile" $cache_from "$build"


### PR DESCRIPTION
Replicating behaviour of `tag_file` allow the `put` target repository to be driven from concourse task.

Image tag is generated within a concourse job, passed to Put as output.
PR allows for the repository to be defined also. 
Example, if multi repos are to be used depending on if final built image is to be label as a PR or a Release.