### PR TITLE
bug: issue 267 alpine docker build fails

### DIFF
--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # stage: builder
-FROM golang:alpine AS builder
+FROM concourse/golang-builder AS builder
 
 COPY . /go/src/github.com/concourse/docker-image-resource
 ENV CGO_ENABLED 0


### PR DESCRIPTION
There should be no differences in the `builder` stage between the ubuntu and
alpine docker images. The only difference should be in the resource stage
which encapsulates all of the distro specific differences.

Fixes #267 