### PR TITLE
fix: dropping versions in check

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -92,7 +92,7 @@ func main() {
 
 	latestDigest, foundLatest := fetchDigest(client, latestManifestURL, request.Source.Repository, tag)
 
-	if request.Version.Digest != "" {
+	if request.Version != nil && request.Version.Digest != "" {
 		digestRef, err := reference.WithDigest(namedRef, digest.Digest(request.Version.Digest))
 		fatalIf("failed to build cursor manifest URL", err)
 

--- a/cmd/check/models.go
+++ b/cmd/check/models.go
@@ -22,8 +22,8 @@ type Version struct {
 }
 
 type CheckRequest struct {
-	Source  Source  `json:"source"`
-	Version Version `json:"version"`
+	Source  Source   `json:"source"`
+	Version *Version `json:"version"`
 }
 
 type CheckResponse []Version

--- a/tests/check_test.go
+++ b/tests/check_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Check", func() {
 		session := check(map[string]interface{}{
 			"source": map[string]interface{}{
 				"repository": repository,
-				"tag": tag,
+				"tag":        tag,
 			},
 		})
 

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Out", func() {
 			},
 		}, map[string]string{
 			"STARTUP_TIMEOUT": "5",
-			"FAIL_ONCE": "true",
+			"FAIL_ONCE":       "true",
 		})
 
 		Expect(session.Err).To(gbytes.Say("(?s:DOCKERD.*DOCKERD.*)"))
@@ -90,7 +90,7 @@ var _ = Describe("Out", func() {
 			},
 		}, map[string]string{
 			"STARTUP_TIMEOUT": "1",
-			"FAIL_ONCE": "true",
+			"FAIL_ONCE":       "true",
 		})
 
 		Expect(session.Err).To(gbytes.Say(".*Docker failed to start.*"))
@@ -220,14 +220,13 @@ var _ = Describe("Out", func() {
 					},
 				},
 			}, map[string]string{
-				"BUILD_ID":		"value of the:\nBUILD_ID envvar",
-				"BUILD_NAME":		"value of the:\nBUILD_NAME envvar",
-				"BUILD_JOB_NAME":	"value of the:\nBUILD_JOB_NAME envvar",
-				"BUILD_PIPELINE_NAME":	"value of the:\nBUILD_PIPELINE_NAME envvar",
-				"BUILD_TEAM_NAME":	"value of the:\nBUILD_TEAM_NAME envvar",
-				"ATC_EXTERNAL_URL":	"value of the:\nATC_EXTERNAL_URL envvar",
+				"BUILD_ID":            "value of the:\nBUILD_ID envvar",
+				"BUILD_NAME":          "value of the:\nBUILD_NAME envvar",
+				"BUILD_JOB_NAME":      "value of the:\nBUILD_JOB_NAME envvar",
+				"BUILD_PIPELINE_NAME": "value of the:\nBUILD_PIPELINE_NAME envvar",
+				"BUILD_TEAM_NAME":     "value of the:\nBUILD_TEAM_NAME envvar",
+				"ATC_EXTERNAL_URL":    "value of the:\nATC_EXTERNAL_URL envvar",
 			})
-
 
 			Expect(session.Err).To(gbytes.Say(dockerarg(`--build-arg`)))
 			Expect(session.Err).To(gbytes.Say(dockerarg(`arg01=no envvars`)))
@@ -546,8 +545,8 @@ var _ = Describe("Out", func() {
 					"repository": "test",
 				},
 				"params": map[string]interface{}{
-					"build":      "/docker-image-resource/tests/fixtures/build",
-					"cache":      "true",
+					"build": "/docker-image-resource/tests/fixtures/build",
+					"cache": "true",
 				},
 			})
 			Expect(session.Err).To(gbytes.Say(dockerarg(`--cache-from`)))
@@ -560,8 +559,8 @@ var _ = Describe("Out", func() {
 					"repository": "broken-repo",
 				},
 				"params": map[string]interface{}{
-					"build":     "/docker-image-resource/tests/fixtures/build",
-					"cache":      "true",
+					"build": "/docker-image-resource/tests/fixtures/build",
+					"cache": "true",
 				},
 			})
 
@@ -570,7 +569,7 @@ var _ = Describe("Out", func() {
 			Expect(session.Err).To(gbytes.Say(dockerarg(`build`)))
 
 		})
-	});
+	})
 
 	Context("when cache_from images are specified", func() {
 		BeforeEach(func() {
@@ -597,7 +596,7 @@ var _ = Describe("Out", func() {
 			session := put(map[string]interface{}{
 				"source": map[string]interface{}{
 					"repository": "test",
-				}, 
+				},
 				"params": map[string]interface{}{
 					"build":      "/docker-image-resource/tests/fixtures/build",
 					"cache_from": []string{"cache_from_1", "cache_from_2"},


### PR DESCRIPTION
I fixed dropping versions in check. (based on https://github.com/concourse/concourse/issues/3910#issuecomment-495771128)

I know that this Resource is deprecated and `registry-image-resource` is recommended, but I still want to use this resource because our internal Docker Registry does not support oci.

I confirmed that this change solved the problem.