### PR TITLE
Added optional discovery and errorhandling for load_repository and load_tag parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ version is the image's digest.
 
 * `build_args`: *Optional.* A map of Docker build-time variables. These will be
   available as environment variables during the Docker build.
-  
+
   While not stored in the image layers, they are stored in image metadata and
   so it is recommend to avoid using these to pass secrets into the build
   context. In multi-stage builds `ARG`s in earlier stages will not be copied
   to the later stages, or in the metadata of the final stage.
-  
+
   The
   [build metadata](https://concourse-ci.org/implementing-resources.html#resource-metadata)
   environment variables provided by Concourse will be expanded in the values
@@ -236,11 +236,10 @@ version is the image's digest.
   multiple images.
 
 * `load_file`: *Optional.* A path to a file to `docker load` and then push.
-  Requires `load_repository`.
 
-* `load_repository`: *Optional.* The repository of the image loaded from `load_file`.
+* `load_repository`: *Optional.* Explicitly set the repository of the image loaded from `load_file`.
 
-* `load_tag`: *Optional.* Default `latest`. The tag of image loaded from `load_file`
+* `load_tag`: *Optional.* Explicitly set the tag of the image loaded from `load_file`. Default `latest`. The tag of image loaded from `load_file`
 
 * `pull_repository`: *Optional.* **DEPRECATED. Use `get` and `load` instead.** A
   path to a repository to pull down, and then push to this resource.
@@ -259,7 +258,7 @@ version is the image's digest.
   prepended with this string. This is useful for adding `v` in front of version
   numbers.
 
-* `target_name`: *Optional.*  Specify the name of the target build stage. 
+* `target_name`: *Optional.*  Specify the name of the target build stage.
   Only supported for multi-stage Docker builds
 
 

--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ version is the image's digest.
 
 * `load_file`: *Optional.* A path to a file to `docker load` and then push.
 
-* `load_repository`: *Optional.* Explicitly set the repository of the image loaded from `load_file`.
+* `load_repository`: *Optional.* Explicitly set the repository of the image loaded from `load_file`. If not set, the resource will try to discover the name itself.
 
-* `load_tag`: *Optional.* Explicitly set the tag of the image loaded from `load_file`. Default `latest`. The tag of image loaded from `load_file`
+* `load_tag`: *Optional.* Explicitly set the tag of the image loaded from `load_file`. Default `latest`. The tag of image loaded from `load_file` If not set, the resource will try to discover the tag itself.
 
 * `pull_repository`: *Optional.* **DEPRECATED. Use `get` and `load` instead.** A
   path to a repository to pull down, and then push to this resource.

--- a/assets/out
+++ b/assets/out
@@ -251,8 +251,10 @@ elif [ -n "$load_file" ]; then
     docker tag "${load_repository}:${load_tag}" "${repository}:${tag_name}"
   else
     vartag=$(docker load -i  "$load_file" | awk -F ":" '{print $3}') || echo "Could not automatically discover the loaded image tag"
+    echo "Found tag '$vartag'."
     varimg=$(docker load -i  "$load_file" | awk -F ":" '{print $2}') || echo "Could not automatically discover the loaded image name"
-    docker tag "${varimg}:${vartag}" "${repository}:${tag_name}"
+    echo "Found image '$varimg'."
+    docker tag ${varimg}:${vartag} ${repository}:${tag_name}
   fi
 elif [ -n "$import_file" ]; then
   cat "$import_file" | docker import - "${repository}:${tag_name}"

--- a/assets/out
+++ b/assets/out
@@ -241,7 +241,7 @@ elif [ -n "$build" ]; then
       # see https://github.com/moby/moby/pull/32677
       # and https://github.com/awslabs/amazon-ecr-credential-helper/issues/9
       docker pull "${ecr_image}"
-    done    
+    done
   fi
 
   docker build -t "${repository}:${tag_name}" "${target[@]}" "${expanded_build_args[@]}" "${expanded_labels[@]}" -f "$dockerfile" $cache_from "$build"
@@ -250,8 +250,9 @@ elif [ -n "$load_file" ]; then
     docker load -i "$load_file"
     docker tag "${load_repository}:${load_tag}" "${repository}:${tag_name}"
   else
-    echo "must specify load_repository param"
-    exit 1
+    vartag=$(docker load -i  "$load_file" | awk -F ":" '{print $3}') || echo "Could not automatically discover the loaded image tag"
+    varimg=$(docker load -i  "$load_file" | awk -F ":" '{print $2}') || echo "Could not automatically discover the loaded image name"
+    docker tag "${varimg}:${vartag}" "${repository}:${tag_name}"
   fi
 elif [ -n "$import_file" ]; then
   cat "$import_file" | docker import - "${repository}:${tag_name}"


### PR DESCRIPTION
This PR enables users to skip configuring load_repository and load_tag parameters that must match the image's repository and tag. This helps especially in situations where the tag value can be variable because the image passed in will be a new version, and prevents the tag value needing to be known in the concourse pipeline configuration. 
In general, this makes loading images more straightforward while not losing out on the possibility to set the load_repository and load_tag yourself.