### PR TITLE
Provide option 'load_tag_file' for dynamically reading the load tag from within the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ version is the image's digest.
 
 * `load_tag`: *Optional.* Default `latest`. The tag of image loaded from `load_file`
 
+* `load_tag_file`: *Optional.* Default `<empty>`. The tag of image loaded from `load_file` read 
+  from the given file. Useful for dynamically setting the tag from within the build itself.
+  If set, supersedes `load_tag` if the file can be found and is readable.
+
 * `pull_repository`: *Optional.* **DEPRECATED. Use `get` and `load` instead.** A
   path to a repository to pull down, and then push to this resource.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
  * `max_concurrent_uploads`: *Optional.* Maximum concurrent uploads.
 
    Limits the number of concurrent upload threads.
+   
+  * `debug`: *Optional (default: false).*
+  If set to `true` the bash tracing (`set -x`) will be enabled for the `in`, `out` and `check` scripts.
 
 ## Behavior
 

--- a/assets/in
+++ b/assets/in
@@ -22,6 +22,12 @@ payload=$(mktemp /tmp/resource-in.XXXXXX)
 
 cat > $payload <&0
 
+enable_debug=$(jq -r '.source.debug // false' < ${payload})
+if [ "${enable_debug}" = "true" ]; then
+  echo "Enable debug mode"
+  set -x
+fi
+
 insecure_registries=$(jq -r '.source.insecure_registries // [] | join(" ")' < $payload)
 
 registry_mirror=$(jq -r '.source.registry_mirror // ""' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -22,6 +22,12 @@ payload=$(mktemp /tmp/resource-in.XXXXXX)
 
 cat > $payload <&0
 
+enable_debug=$(jq -r '.source.debug // false' < ${payload})
+if [ "${enable_debug}" = "true" ]; then
+  echo "Enable debug mode"
+  set -x
+fi
+
 cd $source
 
 insecure_registries=$(jq -r '.source.insecure_registries // [] | join(" ")' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -113,6 +113,16 @@ dockerfile=$(jq -r ".params.dockerfile // \"${build}/Dockerfile\"" < $payload)
 load_file=$(jq -r '.params.load_file // ""' < $payload)
 load_repository=$(jq -r '.params.load_repository // ""' < $payload)
 load_tag=$(jq -r '.params.load_tag // "latest"' < $payload)
+load_tag_file=$(jq -r '.params.load_tag_file // ""' < $payload)
+
+load_tag_name="$load_tag"
+if [ -n "$load_tag_file" ]; then
+  if [ ! -f "$load_tag_file" ]; then
+    echo "load_tag_file '$load_tag_file' does not exist"
+    exit 1
+  fi
+  load_tag_name="$(cat $load_tag_file)"
+fi
 
 import_file=$(jq -r '.params.import_file // ""' < $payload)
 
@@ -254,7 +264,8 @@ elif [ -n "$build" ]; then
 elif [ -n "$load_file" ]; then
   if [ -n "$load_repository" ]; then
     docker load -i "$load_file"
-    docker tag "${load_repository}:${load_tag}" "${repository}:${tag_name}"
+    echo "Using load tag: $load_tag_name"
+    docker tag "${load_repository}:${load_tag_name}" "${repository}:${tag_name}"
   else
     echo "must specify load_repository param"
     exit 1


### PR DESCRIPTION
The PR provides the following enhancements to the resource:

- Add configuration option `debug` for turning on bash tracing of the resource
- Add opportunity to read the `load_tag` from a file during the build. The file can be specified via new config option `load_tag_file`

Fixes #296