### PR TITLE
added note in readme regarding private registry hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
 * `repository`: *Required.* The name of the repository, e.g.
 `concourse/docker-image-resource`.
 
+  Note: When configuring a private registry which requires a login the 
+  registry's hostname must contain at least one '.' e.g. `registry.local`. 
+  Otherwise docker hub will be used.
   Note: When configuring a private registry **using a non-root CA**,
   you must include the port (e.g. :443 or :5000) even though the docker CLI
   does not require it.


### PR DESCRIPTION
I'm hosting concourse with a private registry which requires a `docker login` within the same docker-compose file. The service for my registry was called `harbor`. 
I've stumbled upon this behavior as i wasn't able to put a docker image resource to this registry as it always tried to login to docker hub. 
This behavior origins in the `private_registry()` function in `common.sh` https://github.com/concourse/docker-image-resource/blob/f7dfbc17c2f633eb165e1fc5b7363b582af6a7e3/assets/common.sh#L124-L135 as it checks if the first part of the docker image name contains a `.` to mark it as private e.g. `registry.example.com`. However when you use the name `registry` in the docker-compose file for your services hostname it will break.

As is don't want to change the default behavior and have no better idea how to check if the registry is private or simply a repository on docker hub i added a note in the readme about the naming convention for those private registry hostnames. 
