### PR TITLE
Better check for private registry or dockerhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
 * `repository`: *Required.* The name of the repository, e.g.
 `concourse/docker-image-resource`.
 
-  Note: When configuring a private registry which requires a login the
-  registry's hostname must contain at least one '.' e.g. `registry.local`.
+  Note: When configuring a private registry which requires a login, the 
+  registry's address must contain at least one '.' e.g. `registry.local` 
+  or contain the port (e.g. `registry:443` or `registry:5000`).
   Otherwise docker hub will be used.
+  
   Note: When configuring a private registry **using a non-root CA**,
   you must include the port (e.g. :443 or :5000) even though the docker CLI
   does not require it.

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -124,11 +124,9 @@ log_in() {
 private_registry() {
   local repository="${1}"
 
-  if echo "${repository}" | fgrep -q '/' ; then
-    local registry="$(extract_registry "${repository}")"
-    if echo "${registry}" | fgrep -q '.' ; then
-      return 0
-    fi
+  local registry="$(extract_registry "${repository}")"
+  if echo "${registry}" | grep -q -x '.*[.:].*' ; then
+    return 0
   fi
 
   return 1


### PR DESCRIPTION
I improved the checks for the detection if the registry is private or dockerhub.
I check if either "." or ":" (or both) are present in the address.
I tested the relevant functions with this little script that reflects all changes i made in this PR. I also modified the Readme according to this new behavior.

```bash
#!/bin/bash

declare -a registries=("registry"
                "registry/foo"
                "registry:5000"
                "registry:5000/foo"
                "registry.local"
                "registry.local/foo"
                "registry.local:5000"
                "registry.local:5000/foo")

extract_registry() {
  local repository="${1}"

  echo "${repository}" | cut -d/ -f1
}

extract_repository() {
  local long_repository="${1}"

  echo "${long_repository}" | cut -d/ -f2-
}

private_registry() {
  local repository="${1}"

  local registry="$(extract_registry "${repository}")"
  if echo "${registry}" | grep -q -x '.*[.:].*' ; then
    return 0
  fi

  return 1
}

test() {
  for reg in "${registries[@]}"; do
    private_registry $reg
    echo $? $reg
  done
}

test
```

Result (0 means private, 1 means not private):
```
1 registry
1 registry/foo
0 registry:5000
0 registry:5000/foo
0 registry.local
0 registry.local/foo
0 registry.local:5000
0 registry.local:5000/foo
```

Also tests are successful

```
docker build -t docker-image-resource -f dockerfiles/ubuntu/Dockerfile .
docker build -t docker-image-resource -f dockerfiles/alpine/Dockerfile .
```