### PR TITLE
Prevent 'registry_mirror' from overwriting the hostname in a 'repository' containing a registry host name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
 * `repository`: *Required.* The name of the repository, e.g.
 `concourse/docker-image-resource`.
 
-  Note: When configuring a private registry which requires a login the 
-  registry's hostname must contain at least one '.' e.g. `registry.local`. 
+  Note: When configuring a private registry which requires a login the
+  registry's hostname must contain at least one '.' e.g. `registry.local`.
   Otherwise docker hub will be used.
   Note: When configuring a private registry **using a non-root CA**,
   you must include the port (e.g. :443 or :5000) even though the docker CLI
@@ -36,6 +36,10 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
   This option overrides any entries in `ca_certs` with the same address.
 
 * `registry_mirror`: *Optional.* A URL pointing to a docker registry mirror service.
+
+  Note: `registry_mirror` is ignored if `repository` contains an explicitly-declared
+  registry-hostname-prefixed value, such as `my-registry.com/foo/bar`, in which case
+  the registry cited in the `repository` value is used instead of the `registry_mirror`.
 
 * `ca_certs`: *Optional.* An array of objects with the following format:
 

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -261,7 +261,7 @@ func parseRepository(repository string) (string, string) {
 	segs := strings.Split(repository, "/")
 
 	if len(segs) > 1 && (strings.Contains(segs[0], ":") || strings.Contains(segs[0], ".")) {
-		// In a private regsitry pretty much anything is valid.
+		// In a private registry pretty much anything is valid.
 		return segs[0], strings.Join(segs[1:], "/")
 	}
 	switch len(segs) {

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -57,10 +57,11 @@ func main() {
 
 	registryHost, repo := parseRepository(request.Source.Repository)
 
-	if len(request.Source.RegistryMirror) > 0 {
-		registryMirrorUrl, err := url.Parse(request.Source.RegistryMirror)
+	explicitlyDeclaredRegistryHost := hasExplicitlyDeclaredRegistryHost(registryHost)
+	if len(request.Source.RegistryMirror) > 0 && !explicitlyDeclaredRegistryHost {
+		registryMirrorURL, err := url.Parse(request.Source.RegistryMirror)
 		fatalIf("failed to parse registry mirror URL", err)
-		registryHost = registryMirrorUrl.Host
+		registryHost = registryMirrorURL.Host
 	}
 
 	tag := string(request.Source.Tag)
@@ -275,6 +276,12 @@ func parseRepository(repository string) (string, string) {
 
 	fatal("malformed repository url")
 	panic("unreachable")
+}
+
+// Does the repository include an explicitly declared registry host, such as 'foo.com/baz/bar'
+// that differs from the officialRegistry?
+func hasExplicitlyDeclaredRegistryHost(registryHost string) bool {
+	return strings.Contains(registryHost, ".") && registryHost != officialRegistry
 }
 
 func isInsecure(hostOrCIDR string, hostPort string) bool {


### PR DESCRIPTION
This addresses issue #305 

I'm also happy to ~write tests~ and/or provider further tweaks, but thought it might be worth getting some early feedback before doing so. Thanks!

Update: I went ahead and wrote a few tests :)