### PR TITLE
Fix Check implementation to properly use HEAD requests

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -91,7 +91,7 @@ func main() {
 	latestManifestURL, err := ub.BuildManifestURL(taggedRef)
 	fatalIf("failed to build latest manifest URL", err)
 
-	latestDigest, foundLatest := fetchDigest(client, latestManifestURL, request.Source.Repository, tag)
+	latestDigest, foundLatest := headDigest(client, latestManifestURL, request.Source.Repository, tag)
 
 	if request.Version.Digest != "" {
 		digestRef, err := reference.WithDigest(namedRef, digest.Digest(request.Version.Digest))
@@ -100,7 +100,7 @@ func main() {
 		cursorManifestURL, err := ub.BuildManifestURL(digestRef)
 		fatalIf("failed to build manifest URL", err)
 
-		cursorDigest, foundCursor := fetchDigest(client, cursorManifestURL, request.Source.Repository, tag)
+		cursorDigest, foundCursor := headDigest(client, cursorManifestURL, request.Source.Repository, tag)
 
 		if foundCursor && cursorDigest != latestDigest {
 			response = append(response, Version{cursorDigest})


### PR DESCRIPTION
Fixes #311

This changes the check flow to call headDigest instead of fetchDigest directly.
If headDigest fails to get the digest it will fall back to using fetchDigest.

Tested in the following scenarios:
- Upstream to dockerhub with library and user repos
- Against private nexus registry with pull-through cache both directly and with registry_mirror
- Against the repo called out in #307 which spawned the initial change.

This fix is required for us to upgrade to 6.7.x as the nexus pull-through-cache works with HEAD requests and not GET requests for check
(problem for another day) as well as important for the Dockerhub ratelimiting on Nov 2