### PR TITLE
Skip Systemd cgroup creation on systems with OpenRC

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -41,7 +41,7 @@ sanitize_cgroups() {
     fi
   done
 
-  if ! test -e /sys/fs/cgroup/systemd ; then
+  if [ ! -e /sys/fs/cgroup/systemd ] && [ $(cat /proc/self/cgroup | grep '^1:name=openrc:' | wc -l) -eq 0 ]; then
     mkdir /sys/fs/cgroup/systemd
     mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
   fi


### PR DESCRIPTION
In short, forcefully creating systemd cgroups on systems without systemd makes Docker fail with same error as in https://github.com/concourse/docker-image-resource/commit/264b3718b5b85d850c208159fe2dd364620a83d1  - `docker: Error response from daemon: cgroups: cannot find cgroup mount destination: unknown.` just this time it hapens on host system.
( Previously reported as https://github.com/vito/oci-build-task/issues/27 )

To make things more fun, some systems have cgroups auto-cleaning, so after container is destroyed everything will work again.

This PR tries to fix this behavior on OpenRC systems, my knowledge about cgroups is shallow but it seems to not break anything.

How to reproduce problem:

Vagrantfile:
```
$script = <<-SCRIPT
apk add docker
/etc/init.d/docker start
SCRIPT

Vagrant.configure("2") do |config|
  config.vm.define "alpine" do |config|
  config.vm.hostname = "test"
  config.vm.box = "generic/alpine312"
  config.vm.box_check_update = false
  config.vm.provider :libvirt do |v|
    v.memory = 1024
    v.cpus = 1
    end
  end
  config.vm.provision "shell", inline: $script
end
```

In first terminal:
```
test:/home/vagrant# docker run --rm -it alpine:3.11 echo test
test
```
In second terminal:
```
docker run --rm -it --privileged concourse/docker-image-resource bash -c "echo '"'{"source":{"repository":"alpine","tag":"3.11"}}'"' | /opt/resource/in /example; sleep 30s"
```
And then back in first terminal:
```
test:/home/vagrant# docker run --rm -it alpine:3.11 echo test
docker: Error response from daemon: cgroups: cannot find cgroup mount destination: unknown.
ERRO[0001] error waiting for container: context canceled
```

After 30s, container with `docker-image-resource` will exit, systemd cgroup will be removed and hosts docker will work again.