### PR TITLE
Feature: build image once

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ version is the image's digest.
   { "EMAIL": "me@yopmail.com", "HOW_MANY_THINGS": 1, "DO_THING": false }
   ```
 
+* `build_once`: *Optional.* If this parameter is set to "true", the resource will check the image existence in the registry to avoid rebuilding unnecessarily the image.
+  
 * `cache`: *Optional.* Default `false`. When the `build` parameter is set,
   first pull `image:tag` from the Docker registry (so as to use cached
   intermediate images when building). This will cause the resource to fail

--- a/assets/out
+++ b/assets/out
@@ -68,6 +68,7 @@ build_args_file=$(jq -r '.params.build_args_file // ""' < $payload)
 labels=$(jq -r '.params.labels // {}' < $payload)
 labels_file=$(jq -r '.params.labels_file // ""' < $payload)
 
+build_once=$(jq -r '.params.build_once // "false"' <$payload)
 
 tag_name=""
 if [ -n "$tag_params" ]; then
@@ -244,7 +245,14 @@ elif [ -n "$build" ]; then
     done
   fi
 
-  docker build -t "${repository}:${tag_name}" "${target[@]}" "${expanded_build_args[@]}" "${expanded_labels[@]}" -f "$dockerfile" $cache_from "$build"
+  if [ "${build_once}" = "true" ]; then
+    if ! docker pull "${repository}:${tag_name}"; then
+      docker build -t "${repository}:${tag_name}" "${target[@]}" "${expanded_build_args[@]}" "${expanded_labels[@]}" -f "$dockerfile" $cache_from "$build"
+    fi
+  else
+      docker build -t "${repository}:${tag_name}" "${target[@]}" "${expanded_build_args[@]}" "${expanded_labels[@]}" -f "$dockerfile" $cache_from "$build"
+  fi
+
 elif [ -n "$load_file" ]; then
   if [ -n "$load_repository" ]; then
     docker load -i "$load_file"


### PR DESCRIPTION
This feature is for that cases if you don't want to build image it it already exists in the image registry.
By default it not changes behavior. To enable this feature was added a new flag `build_once`. 