### PR TITLE
Output contents of log file on error

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -94,7 +94,7 @@ start_docker() {
   trap stop_docker EXIT
 
   if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
-    cat "${LOG_FILE}"
+    [ -f "$LOG_FILE" ] && cat "${LOG_FILE}"
     echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
     return 1
   fi

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -94,6 +94,7 @@ start_docker() {
   trap stop_docker EXIT
 
   if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
+    cat "${LOG_FILE}"
     echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
     return 1
   fi


### PR DESCRIPTION
This PR outputs the contents of the log file to console in the event docker fails to start. A lot of my users are having issues with docker starting, and troubleshooting is difficult without this information. The containers have often been garbage collected by the time I come to investigate.

Signed-off-by: Tom Bartlett <tom.bartlett@spire.com>