### PR TITLE
Fix broken interaction of BUILDKIT and docker ecr_login plugin

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -118,7 +118,9 @@ log_in() {
     echo "${password}" | docker login -u "${username}" --password-stdin ${registry}
   else
     mkdir -p ~/.docker
-    echo '{"credsStore":"ecr-login"}' >> ~/.docker/config.json
+    touch ~/.docker/config.json
+    # This ensures the resulting JSON object remains syntactically valid
+    echo "$(cat ~/.docker/config.json){\"credsStore\":\"ecr-login\"}" | jq -s add > ~/.docker/config.json
   fi
 }
 

--- a/assets/out
+++ b/assets/out
@@ -38,7 +38,6 @@ max_concurrent_uploads=$(jq -r '.source.max_concurrent_uploads // 3' < $payload)
 export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // ""' < $payload)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // ""' < $payload)
 export AWS_SESSION_TOKEN=$(jq -r '.source.aws_session_token // ""' < $payload)
-export DOCKER_BUILDKIT=$(jq -r '.source.docker_buildkit // 0' < $payload)
 
 if private_registry "${repository}" ; then
   registry="$(extract_registry "${repository}")"
@@ -104,7 +103,7 @@ cache=$(jq -r '.params.cache' < $payload)
 cache_tag=$(jq -r ".params.cache_tag // \"${tag_name}\"" < $payload)
 cache_from=$(jq -r '.params.cache_from // empty' < $payload)
 dockerfile=$(jq -r ".params.dockerfile // \"${build}/Dockerfile\"" < $payload)
-
+export DOCKER_BUILDKIT=$(jq -r '.params.docker_buildkit // 0' < $payload)
 load_file=$(jq -r '.params.load_file // ""' < $payload)
 load_repository=$(jq -r '.params.load_repository // ""' < $payload)
 load_tag=$(jq -r '.params.load_tag // "latest"' < $payload)
@@ -245,7 +244,11 @@ elif [ -n "$build" ]; then
     done
   fi
 
-  docker build -t "${repository}:${tag_name}" "${target[@]}" "${expanded_build_args[@]}" "${expanded_labels[@]}" -f "$dockerfile" $cache_from "$build"
+  # NOTE: deactivate amazon-ecr-credential-helper so that builds go through with the DOCKER_BUILDKIT set
+  cat <<< "$(jq 'del(.credsStore)' ~/.docker/config.json)" > ~/.docker/config.json
+  docker build -t "${repository}:${tag_name}" "${target[@]}" "${expanded_build_args[@]}" "${expanded_labels[@]}" "${ssh_args[@]}" -f "$dockerfile" $cache_from "$build"
+  log_in "$username" "$password" "$registry" # This restores the credsStore: ecr-login to config.json if needed
+
 elif [ -n "$load_file" ]; then
   if [ -n "$load_repository" ]; then
     docker load -i "$load_file"


### PR DESCRIPTION
When running within docker-in-docker context, and more specifically in this resource, and only when buildkit is enabled, there is an issue with the aws `ecr_login` authenticator plugin of docker.  Specifically, it gets confused and tries to authenticate attempts to fetch from non-ECR registries.  It then gives up errors such as "xxx... is not a valid repository URI for Amazon Elastic Container Registry" for layers from say, docker hub, and the `docker build` fails.

Fortunately, there is already code in `assets/out:242` which does an explicit pull for base images from ECR, if any, which means, the `docker build` step doesn't actually need the `ecr_login` plugin.

This PR removes the `ecr_login` plugin while calling `docker build`, and then puts it back immediately after.

I have tested that pushing to ECR still works after this patch, so the plugin still works.