### PR TITLE
Skip cgroup sanitization for cgroup v2

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -3,6 +3,10 @@ SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
 STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-120}
 
 sanitize_cgroups() {
+  if [ -e /sys/fs/cgroup/cgroup.controllers ]; then
+    return
+  fi
+
   mkdir -p /sys/fs/cgroup
   mountpoint -q /sys/fs/cgroup || \
     mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup


### PR DESCRIPTION
On cgroup v2 systems (like fedora v31+) the cgroup sanitization will fail with a error message like
```
mount: /sys/fs/cgroup/cpuset: cgroup already mounted on /sys/fs/cgroup.
```

(The exact mountpoint probably depends on the available cgroups).

This simply bails out, as this mounting is no longer necessary with cgroup v2.

This was tested on a cgroup v2 system using a containerd runner.
