### PR TITLE
Add image labels to metadata

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -76,6 +76,7 @@ if [ "$skip_download" = "false" ]; then
 
   echo "$image_id" > ${destination}/image-id
   docker inspect $image_id > ${destination}/docker_inspect.json
+  labels="$(cat ${destination}/docker_inspect.json | jq -r '.[0].Config.Labels // {} | to_entries | map("\(.key)=\(.value)") | join(", ")')"
 
   docker run \
     --cidfile=/tmp/container.cid \
@@ -102,6 +103,7 @@ jq -n "{
   metadata: [
     { name: \"repository\", value: $(echo $repository | jq -R .) },
     { name: \"tag\", value: $(echo $tag | jq -R .) },
-    { name: \"image\", value: $(echo $image_id | head -c 12 | jq -R .) }
+    { name: \"image\", value: $(echo $image_id | head -c 12 | jq -R .) },
+    { name: \"labels\", value: $(echo $labels | jq -R .) }
   ]
 }" | jq '{version: .version} + {metadata: [.metadata[] | select(.value != "")]}' >&3


### PR DESCRIPTION
This PR adds the image's labels as a comma separated string to the version's metadata. Labels contain valuable metadata and in our case we encode information about the git commit that produced the image. This is useful information to display in the UI when viewing the build logs as well as the version list page when users they can use the labels to enable/disable/pin versions.

I have tested that the `$labels` variable contains the correct comma separated string when there are labels (see screenshot) and is an empty string when there are not.

![image](https://user-images.githubusercontent.com/13096680/124838549-ef8d2000-df3b-11eb-9bd7-8bde9fc06596.png)
