### PR TITLE
fixing docker login issue due 2 logins we are performing during put

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -117,7 +117,7 @@ log_in() {
   local username="$1"
   local password="$2"
   local registry="$3"
-
+  docker logout
   if [ -n "${username}" ] && [ -n "${password}" ]; then
     echo "${password}" | docker login -u "${username}" --password-stdin ${registry}
   else


### PR DESCRIPTION
When we are building and pushing a docker image via the resource we faced login error issue. Up on investigation it is something related to this [ISSUE](https://github.com/docker/hub-feedback/issues/1250). As per the issue, it says login fails for 2 reasons. 1. Due to password having special chars and 2. login is happening V2 [this gets solved via logout and login again].

As per the analysis I have done, looks like first [login](https://github.com/concourse/docker-image-resource/blob/master/assets/out#L55) is happening/happened via V1 and during second [login](https://github.com/concourse/docker-image-resource/blob/master/assets/out#L250) it tried via V2 and failure is seen.

![image](https://user-images.githubusercontent.com/42992083/157666503-2df38cc8-f5af-4b86-a413-915c8dcad71e.png)

![image](https://user-images.githubusercontent.com/42992083/157666577-d1b02b08-e6fc-4f71-a74d-30a721175c4f.png)

![image](https://user-images.githubusercontent.com/42992083/157666101-9a33383e-0554-43ac-b9cf-e4caf4fb012a.png)

![image](https://user-images.githubusercontent.com/42992083/157666082-11c7364e-488c-4740-a8e5-53563c131fc1.png)

sometime I am seeing the issue while performing get after successful PUT or at first login of the PUT. 
Though the containers used for PUT and GET are different, somehow there is login that happened already in these containers and it ends up in failing as it tries to login as part in/out script.

Failure for GET image post PUT
![image](https://user-images.githubusercontent.com/42992083/157667237-7b059b4a-563e-440b-9f3c-9ba9e107f67f.png)

Failure for First Login for PUT
![image](https://user-images.githubusercontent.com/42992083/157667367-d87b5d8b-29f6-4554-af3d-8e6fb10f08ec.png)


I think doing a logout before logging in is a safe option to avoid this situation. 

Request you to review and merge this PR.
