### PR TITLE
add support for authenticating to additional docker registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
 
 * `password`: *Optional.* The password to use when authenticating.
 
+* `additional_private_registries`: *Optional.* An array of objects with the
+  following format:
+
+  ```yaml
+  additional_private_registries:
+  - registry: example.com/my-private-docker-registry
+    username: my-username
+    password: ((my-secret:my-secret))
+  - registry: example.com/another-private-docker-registry
+    username: another-username
+    password: ((another-secret:another-secret))
+  ```
+
+  Each entry specifies a private docker registry and credentials to be passed
+  to `docker login`. This is used when a Dockerfile contains a FROM instruction
+  referring to an image hosted in a docker registry that requires a login.
+
 * `aws_access_key_id`: *Optional.* AWS access key to use for acquiring ECR
   credentials.
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -118,12 +118,6 @@ log_in() {
   local password="$2"
   local registry="$3"
 
-  # workaround for docker hub login problem https://github.com/concourse/docker-image-resource/pull/343 https://github.com/docker/hub-feedback/issues/1250
-  if [[ -z ${registry} ]]; then
-    # if $registry is empty, that implies that we are trying to auth to docker hub, and we need this workaround
-    docker logout https://index.docker.io/v1/
-  fi
-
   if [ -n "${username}" ] && [ -n "${password}" ]; then
     echo "${password}" | docker login -u "${username}" --password-stdin ${registry}
   else

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -117,7 +117,13 @@ log_in() {
   local username="$1"
   local password="$2"
   local registry="$3"
-  docker logout
+
+  # workaround for docker hub login problem https://github.com/concourse/docker-image-resource/pull/343 https://github.com/docker/hub-feedback/issues/1250
+  if [[ -z ${registry} ]]; then
+    # if $registry is empty, that implies that we are trying to auth to docker hub, and we need this workaround
+    docker logout https://index.docker.io/v1/
+  fi
+
   if [ -n "${username}" ] && [ -n "${password}" ]; then
     echo "${password}" | docker login -u "${username}" --password-stdin ${registry}
   else

--- a/assets/out
+++ b/assets/out
@@ -52,6 +52,21 @@ start_docker \
 	"${max_concurrent_uploads}" \
 	"$insecure_registries" \
 	"$registry_mirror"
+
+
+# idea to use base64 to iterate over an array of json objects
+# borrowed from https://www.starkandwayne.com/blog/bash-for-loop-over-json-array-using-jq/
+additional_private_registries_base64=$(jq -r '.source.additional_private_registries // []' < $payload | jq -r '.[] | @base64')
+
+# authenticate to additional registries (if any)
+for base64_line in ${additional_private_registries_base64}; do
+  additional_registry=$(echo $base64_line | base64 --decode | jq -r '.registry')
+  additional_username=$(echo $base64_line | base64 --decode | jq -r '.username')
+  additional_password=$(echo $base64_line | base64 --decode | jq -r '.password')
+  log_in "$additional_username" "$additional_password" "$additional_registry"
+done
+
+# authenticate to primary registry last
 log_in "$username" "$password" "$registry"
 
 tag_source=$(jq -r '.source.tag // "latest"' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -262,7 +262,7 @@ elif [ -n "$build" ]; then
   cp ~/.docker/config.json ~/.docker/config.json.bak
   cat <<< "$(jq 'del(.credsStore)' ~/.docker/config.json)" > ~/.docker/config.json
   docker build -t "${repository}:${tag_name}" "${target[@]}" "${expanded_build_args[@]}" "${expanded_labels[@]}" "${ssh_args[@]}" -f "$dockerfile" $cache_from "$build"
-  mv ~/.docker/config.json.bak ~/.docker/config.json
+  mv ~/.docker/config.json.bak ~/.docker/config.json # This restores the credsStore: ecr-login to config.json if needed
 
 elif [ -n "$load_file" ]; then
   if [ -n "$load_repository" ]; then

--- a/assets/out
+++ b/assets/out
@@ -53,7 +53,6 @@ start_docker \
 	"$insecure_registries" \
 	"$registry_mirror"
 
-
 # idea to use base64 to iterate over an array of json objects
 # borrowed from https://www.starkandwayne.com/blog/bash-for-loop-over-json-array-using-jq/
 additional_private_registries_base64=$(jq -r '.source.additional_private_registries // []' < $payload | jq -r '.[] | @base64')

--- a/assets/out
+++ b/assets/out
@@ -259,9 +259,10 @@ elif [ -n "$build" ]; then
   fi
 
   # NOTE: deactivate amazon-ecr-credential-helper so that builds go through with the DOCKER_BUILDKIT set
+  cp ~/.docker/config.json ~/.docker/config.json.bak
   cat <<< "$(jq 'del(.credsStore)' ~/.docker/config.json)" > ~/.docker/config.json
   docker build -t "${repository}:${tag_name}" "${target[@]}" "${expanded_build_args[@]}" "${expanded_labels[@]}" "${ssh_args[@]}" -f "$dockerfile" $cache_from "$build"
-  log_in "$username" "$password" "$registry" # This restores the credsStore: ecr-login to config.json if needed
+  mv ~/.docker/config.json.bak ~/.docker/config.json
 
 elif [ -n "$load_file" ]; then
   if [ -n "$load_repository" ]; then


### PR DESCRIPTION
This PR adds a new optional config parameter `additional_private_registries`, which allows a pipeline to authenticate to multiple docker registries.  

This is useful when trying to build a Dockerfile that depends on an image that is only available from a private registry, which is separate from the registry where the resulting docker image will be published.  For example, pulling from a private 3rd party docker registry and publishing to an internal docker registry, or transitioning to a new docker registry while still allowing pulls from an old docker registry.  

I have built this resource locally and tested it with our Concourse, per the instructions in the README.  When specifying additional registries, the resource successfully authenticated to all of them, and published the image as expected.  The resource still works as expected when no additional registries are configured.  

My only concern is with the workaround to the dockerhub login problem, introduced in https://github.com/concourse/docker-image-resource/pull/343.  This change always runs `docker logout` prior to calling `docker login`, which prevents `additional_private_registries` from working.  So, I read the PR and the linked issue carefully, and I think I've come up with a more surgical way of using `docker logout` to work around the problem without removing the credentials set by `additional_private_registries`.  However, I can't reproduce that issue in the first place, so I can't be sure that this workaround is still effective for people who face this problem with dockerhub.  

Other than that, I think this change is ready to go!  Thanks for reading my pull-request!  