### PR TITLE
fix additional_private_registries on alpine

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -59,9 +59,9 @@ additional_private_registries_base64=$(jq -r '.source.additional_private_registr
 
 # authenticate to additional registries (if any)
 for base64_line in ${additional_private_registries_base64}; do
-  additional_registry=$(echo $base64_line | base64 --decode | jq -r '.registry')
-  additional_username=$(echo $base64_line | base64 --decode | jq -r '.username')
-  additional_password=$(echo $base64_line | base64 --decode | jq -r '.password')
+  additional_registry=$(echo $base64_line | base64 -d | jq -r '.registry')
+  additional_username=$(echo $base64_line | base64 -d | jq -r '.username')
+  additional_password=$(echo $base64_line | base64 -d | jq -r '.password')
   log_in "$additional_username" "$additional_password" "$additional_registry"
 done
 

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -271,6 +271,42 @@ var _ = Describe("Out", func() {
 		})
 	})
 
+	Context("when configured with additional private registries", func() {
+		It("passes them to docker login", func() {
+			session := put(map[string]interface{}{
+				"source": map[string]interface{}{
+					"repository": "test",
+					"additional_private_registries": []interface{}{
+						map[string]string{
+							"registry": "example.com/my-private-docker-registry",
+							"username": "my-username",
+							"password": "my-secret",
+						},
+						map[string]string{
+							"registry": "example.com/another-private-docker-registry",
+							"username": "another-username",
+							"password": "another-secret",
+						},
+					},
+				},
+				"params": map[string]interface{}{
+					"build": "/docker-image-resource/tests/fixtures/build",
+				},
+			})
+
+			Expect(session.Err).To(gbytes.Say(dockerarg(`login`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`-u`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`my-username`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`--password-stdin`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`example.com/my-private-docker-registry`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`login`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`-u`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`another-username`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`--password-stdin`)))
+			Expect(session.Err).To(gbytes.Say(dockerarg(`example.com/another-private-docker-registry`)))
+		})
+	})
+
 	Context("when configured with a insecure registries", func() {
 		It("passes them to dockerd", func() {
 			session := put(map[string]interface{}{


### PR DESCRIPTION
The `additional_private_registries` parameter (from this PR: https://github.com/concourse/docker-image-resource/pull/345)  is broken when when this resource type is built using the alpine linux Dockerfile, but it works as intended using the ubuntu Dockerfile.  

The reason for this is because alpine's `base64` doesn't accept `--decode`.  Both ubuntu and alpine understand `-d`, so let's change it to pass that instead.  

Crucially, the docker-image resource type bundled with concourse is built from the alpine Dockerfile, so `additional_private_registries` will not work until this is merged, released, and bundled into a new version of concourse.  