### PR TITLE
Support GCR mirror that send application/vnd.oci.image.index.v1+json

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -52,7 +52,7 @@ func main() {
 	if rECRRepo.MatchString(request.Source.Repository) == true {
 		ecrUser, ecrPass, err := ecr.NewECRHelper(
 			ecr.WithClientFactory(ecrapi.DefaultClientFactory{}),
-        ).Get(request.Source.Repository)
+		).Get(request.Source.Repository)
 		fatalIf("failed to get ECR credentials", err)
 		request.Source.Username = ecrUser
 		request.Source.Password = ecrPass
@@ -119,6 +119,7 @@ func headDigest(client *http.Client, manifestURL, repository, tag string) (strin
 	manifestRequest, err := http.NewRequest("HEAD", manifestURL, nil)
 	fatalIf("failed to build manifest request", err)
 	manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	manifestRequest.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 	manifestRequest.Header.Add("Accept", "application/json")
 
 	manifestResponse, err := client.Do(manifestRequest)
@@ -146,6 +147,7 @@ func fetchDigest(client *http.Client, manifestURL, repository, tag string) (stri
 	manifestRequest, err := http.NewRequest("GET", manifestURL, nil)
 	fatalIf("failed to build manifest request", err)
 	manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	manifestRequest.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 	manifestRequest.Header.Add("Accept", "application/json")
 
 	manifestResponse, err := client.Do(manifestRequest)

--- a/tests/check_test.go
+++ b/tests/check_test.go
@@ -114,6 +114,11 @@ var _ = Describe("Check", func() {
 					),
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("HEAD", "/v2/some/fake-image/manifests/latest"),
+						ghttp.VerifyHeaderKV("Accept",
+							"application/vnd.docker.distribution.manifest.v2+json",
+							"application/vnd.oci.image.index.v1+json",
+							"application/json",
+						),
 						ghttp.RespondWith(http.StatusOK, `{"fake":"manifest"}`, http.Header{
 							"Docker-Content-Digest": {latestFakeDigest},
 						}),


### PR DESCRIPTION
GCR mirror requires [application/vnd.oci.image.index.v1+json](https://github.com/opencontainers/image-spec/blob/main/image-index.md) media type in Accept headers. Otherwise, you will get an error in docker-image-resource that client doesn't accept that media-type and the check command won't be able to fetch the manifest digest.

We were having an issue running the test since the supported ginkgo is outdated, please verify and fix as needed.
