### PR TITLE
feat: add configurable startup_timeout parameter for Docker daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Note: docker registry must be [v2](https://docs.docker.com/registry/spec/api/).
 
    Limits the number of concurrent upload threads.
 
+ * `startup_timeout`: *Optional.* Default `120`. The timeout in seconds to wait 
+   for the Docker daemon to start. Increase this value if you're experiencing
+   timeouts during Docker daemon startup on slower systems.
+
 ## Behavior
 
 ### `check`: Check for new images.

--- a/assets/in
+++ b/assets/in
@@ -34,6 +34,7 @@ ca_certs=$(jq -r '.source.ca_certs // []' < $payload)
 client_certs=$(jq -r '.source.client_certs // []' < $payload)
 max_concurrent_downloads=$(jq -r '.source.max_concurrent_downloads // 3' < $payload)
 max_concurrent_uploads=$(jq -r '.source.max_concurrent_uploads // 3' < $payload)
+startup_timeout=$(jq -r '.source.startup_timeout // 120' < $payload)
 
 export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // ""' < $payload)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // ""' < $payload)
@@ -61,6 +62,7 @@ if [ "$skip_download" = "false" ]; then
   start_docker \
     "${max_concurrent_downloads}" \
     "${max_concurrent_uploads}" \
+    "${startup_timeout}" \
     "$insecure_registries" \
     "$registry_mirror"
 

--- a/assets/out
+++ b/assets/out
@@ -34,6 +34,7 @@ ca_certs=$(jq -r '.source.ca_certs // []' < $payload)
 client_certs=$(jq -r '.source.client_certs // []' < $payload)
 max_concurrent_downloads=$(jq -r '.source.max_concurrent_downloads // 3' < $payload)
 max_concurrent_uploads=$(jq -r '.source.max_concurrent_uploads // 3' < $payload)
+startup_timeout=$(jq -r '.source.startup_timeout // 120' < $payload)
 
 export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // ""' < $payload)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // ""' < $payload)
@@ -50,6 +51,7 @@ set_client_certs "$client_certs"
 start_docker \
 	"${max_concurrent_downloads}" \
 	"${max_concurrent_uploads}" \
+	"${startup_timeout}" \
 	"$insecure_registries" \
 	"$registry_mirror"
 

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -66,14 +66,14 @@ var _ = Describe("Out", func() {
 	It("retries starting dockerd if it fails", func() {
 		session := putWithEnv(map[string]any{
 			"source": map[string]any{
-				"repository": "test",
+				"repository":      "test",
+				"startup_timeout": "5",
 			},
 			"params": map[string]any{
 				"build": "/docker-image-resource/tests/fixtures/build",
 			},
 		}, map[string]string{
-			"STARTUP_TIMEOUT": "5",
-			"FAIL_ONCE":       "true",
+			"FAIL_ONCE": "true",
 		})
 
 		Expect(session.Err).To(gbytes.Say("(?s:DOCKERD.*DOCKERD.*)"))
@@ -82,14 +82,14 @@ var _ = Describe("Out", func() {
 	It("times out retrying dockerd", func() {
 		session := putWithEnv(map[string]any{
 			"source": map[string]any{
-				"repository": "test",
+				"repository":      "test",
+				"startup_timeout": "1",
 			},
 			"params": map[string]any{
 				"build": "/docker-image-resource/tests/fixtures/build",
 			},
 		}, map[string]string{
-			"STARTUP_TIMEOUT": "1",
-			"FAIL_ONCE":       "true",
+			"FAIL_ONCE": "true",
 		})
 
 		Expect(session.Err).To(gbytes.Say(".*Docker failed to start.*"))


### PR DESCRIPTION
Add support for configuring the Docker daemon startup timeout via the source configuration. This allows users to increase the timeout from the default 120 seconds when running on slower systems or under resource constraints.