### PR TITLE
fix for panic on http error

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -340,6 +340,7 @@ func retryRoundTripper(logger lager.Logger, rt http.RoundTripper) http.RoundTrip
 		Logger:         logger,
 		BackOffFactory: retryhttp.NewExponentialBackOffFactory(5 * time.Minute),
 		RoundTripper:   rt,
+		Retryer:        &retryhttp.DefaultRetryer{},
 	}
 }
 


### PR DESCRIPTION
before that change http error triggered the following error:
```
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7f1153]

  goroutine 1 [running]:
  github.com/concourse/retryhttp.(*RetryRoundTripper).RoundTrip.func1()
        github.com/concourse/retryhttp@v1.2.4/retry_round_tripper.go:57 +0xf3
```

after the change the right message is shown:
```
  failed to ping registry: 2 errors occurred:
        * ping https: Get "https://registry-1.docker.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```